### PR TITLE
fix(windows): QR code display and SDK path resolution

### DIFF
--- a/bridge/src/providers/claude-sdk.ts
+++ b/bridge/src/providers/claude-sdk.ts
@@ -4,8 +4,8 @@
  */
 
 import { execSync } from 'node:child_process';
-import { writeFileSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import type { PermissionResult } from '@anthropic-ai/claude-agent-sdk';
@@ -52,7 +52,19 @@ function findClaudeCli(): string | undefined {
   try {
     const result = execSync(cmd, { encoding: 'utf-8', timeout: 5000 }).trim();
     // `where` on Windows may return multiple lines; take the first
-    return result.split('\n')[0]?.trim() || undefined;
+    const found = result.split('\n')[0]?.trim();
+    if (!found) return undefined;
+
+    // On Windows, npm-installed Claude Code exposes a cmd/ps1 wrapper (no
+    // extension) that isn't a native binary. The SDK's query() tries to
+    // spawn it directly and gets ENOENT. Resolve to the actual cli.js
+    // inside the package so the SDK uses `node cli.js` instead.
+    if (process.platform === 'win32') {
+      const cliJs = join(dirname(found), 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
+      if (existsSync(cliJs)) return cliJs;
+    }
+
+    return found;
   } catch {
     return undefined;
   }
@@ -60,7 +72,10 @@ function findClaudeCli(): string | undefined {
 
 function checkCliVersion(cliPath: string): { ok: boolean; version?: string; error?: string } {
   try {
-    const version = execSync(`"${cliPath}" --version`, { encoding: 'utf-8', timeout: 10000 }).trim();
+    // On Windows, .js files are associated with Windows Script Host, not Node.
+    // Prefix with "node" to avoid triggering wscript.exe.
+    const cmd = cliPath.endsWith('.js') ? `node "${cliPath}" --version` : `"${cliPath}" --version`;
+    const version = execSync(cmd, { encoding: 'utf-8', timeout: 10000 }).trim();
     const match = version.match(/(\d+)\.\d+/);
     if (!match || parseInt(match[1]) < 2) {
       return { ok: false, version, error: `Claude CLI ${version} too old (need >= 2.x)` };

--- a/core/cmd/tlive/run.go
+++ b/core/cmd/tlive/run.go
@@ -111,10 +111,14 @@ func runHost(cfg *config.Config, args []string, rows, cols uint16, lockPath stri
 	log.Printf("session created: id=%s cmd=%s args=%v pid=%d", ms.Session.ID, ms.Session.Command, args[1:], ms.Session.Pid)
 	defer mgr.StopSession(ms.Session.ID)
 
-	// Register local output client IMMEDIATELY after session creation to
-	// minimize the window where initial PTY output could be missed.
+	// On non-Windows, register local output client IMMEDIATELY after session
+	// creation to minimize the window where initial PTY output could be missed.
+	// On Windows, defer registration until after the QR code is shown, because
+	// ConPTY output to stdout overwrites the shared console buffer.
 	localClient := &localOutputClient{writer: os.Stdout}
-	ms.Hub.Register(localClient)
+	if runtime.GOOS != "windows" {
+		ms.Hub.Register(localClient)
+	}
 	defer ms.Hub.Unregister(localClient)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -146,12 +150,14 @@ func runHost(cfg *config.Config, args []string, rows, cols uint16, lockPath stri
 	fmt.Fprintf(os.Stderr, "    Local:   %s\n", localURL)
 	fmt.Fprintf(os.Stderr, "    Network: %s\n", url)
 	fmt.Fprintf(os.Stderr, "  Session: %s (ID: %s)\n\n", ms.Session.Command, ms.Session.ID)
-	if runtime.GOOS == "windows" {
-		qrterminal.Generate(url, qrterminal.L, os.Stderr)
-	} else {
-		qrterminal.GenerateHalfBlock(url, qrterminal.L, os.Stderr)
-	}
+	qrterminal.GenerateHalfBlock(url, qrterminal.L, os.Stderr)
 	fmt.Fprintln(os.Stderr)
+
+	// On Windows, register the local output client now (after QR is shown)
+	// and replay any buffered output the child produced while we were printing.
+	if runtime.GOOS == "windows" {
+		ms.Hub.Register(localClient)
+	}
 
 	// Set terminal to raw mode for proper input pass-through
 	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
@@ -217,8 +223,10 @@ func runHost(cfg *config.Config, args []string, rows, cols uint16, lockPath stri
 	var exitCode int
 	select {
 	case exitCode = <-doneCh:
+		ms.Hub.Unregister(localClient)
 		fmt.Fprintf(os.Stderr, "\n  Process exited with code %d\n", exitCode)
 	case sig := <-sigCh:
+		ms.Hub.Unregister(localClient)
 		fmt.Fprintf(os.Stderr, "\n  Received signal: %v\n", sig)
 		ms.Proc.Kill()
 		exitCode = 130
@@ -271,11 +279,7 @@ func runClient(lock daemon.LockInfo, args []string, rows, cols uint16) error {
 	fmt.Fprintf(os.Stderr, "    Local:   %s\n", localURL)
 	fmt.Fprintf(os.Stderr, "    Network: %s\n", url)
 	fmt.Fprintf(os.Stderr, "  Session: %s (ID: %s)\n\n", args[0], sessionID)
-	if runtime.GOOS == "windows" {
-		qrterminal.Generate(url, qrterminal.L, os.Stderr)
-	} else {
-		qrterminal.GenerateHalfBlock(url, qrterminal.L, os.Stderr)
-	}
+	qrterminal.GenerateHalfBlock(url, qrterminal.L, os.Stderr)
 	fmt.Fprintln(os.Stderr)
 
 	// Set terminal to raw mode


### PR DESCRIPTION
## Summary
- **QR code oversized**: Windows used `qrterminal.Generate` (full block), now unified to `GenerateHalfBlock` on all platforms
- **QR code overwritten**: ConPTY child output overwrites shared console buffer; delay `localClient` registration on Windows until after QR is printed
- **Output leaks on exit**: Unregister `localClient` immediately on process exit to prevent ConPTY buffered data leaking to shell prompt
- **SDK ENOENT on npm install**: `where claude` returns npm wrapper script (no extension), SDK treats it as native binary and fails; resolve to actual `cli.js` so SDK spawns via `node`
- **Windows Script Host dialog**: `checkCliVersion` executing `.js` directly triggers wscript.exe; prefix with `node` when path ends in `.js`

## Test plan
- [x] `tlive claude` on Windows: QR code displays at correct size, not overwritten by child process
- [x] `tlive claude` exit: no garbled output after "Process exited"
- [x] IM bridge mode on Windows (npm-installed Claude Code): no ENOENT error, no Windows Script Host dialog
- [x] macOS/Linux: no regression — QR code and bridge work as before