### PR TITLE
ci: add release-please for automated version management

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,16 @@
+name: Release Please
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
-  push:
-    tags: ['v*']
+  release:
+    types: [published]
 
 jobs:
   build-go:
@@ -52,7 +52,7 @@ jobs:
           npm test
           npm run build
 
-  release:
+  upload-assets:
     needs: [build-go, test-bridge]
     runs-on: ubuntu-latest
     permissions:
@@ -63,11 +63,11 @@ jobs:
           merge-multiple: true
       - uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event.release.tag_name }}
           files: tlive-*
-          generate_release_notes: true
 
   publish-npm:
-    needs: release
+    needs: [build-go, test-bridge]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- 新增 release-please workflow，合并到 main 后自动创建 Release PR（含 changelog + version bump）
- release.yml 触发方式从 `push tags` 改为 `release published`，避免与 release-please 重复创建 release
- `coreVersion` 保持手动管理，仅在 Go core 有变更时更新

## 新发版流程

```
合并功能 PR (conventional commit: fix:/feat:/feat!:)
    ↓
release-please 自动创建/更新 Release PR（version bump + CHANGELOG）
    ↓
合并 Release PR
    ↓
release-please 创建 tag + GitHub Release
    ↓
release.yml 触发：构建 Go 二进制 + npm publish
```

## Test plan

- [ ] 合并后观察 release-please 是否自动创建 Release PR
- [ ] 合并 Release PR 后确认 release.yml 正确触发