### PR TITLE
fix(bridge): auto-allow tool after AskUserQuestion approval

### DIFF
--- a/bridge/src/engine/bridge-manager.ts
+++ b/bridge/src/engine/bridge-manager.ts
@@ -753,6 +753,10 @@ export class BridgeManager {
 
     let completedStats: import('./cost-tracker.js').UsageStats | undefined;
 
+    // When an AskUserQuestion is approved, auto-allow the next permission request
+    // to avoid redundant confirmation (e.g. "delete this?" → yes → Bash permission)
+    let askQuestionApproved = false;
+
     // Build SDK-level permission handler based on /perm mode
     const permMode = this.state.getPermMode(msg.channelType, msg.chatId);
     const sdkPermissionHandler = permMode === 'on'
@@ -760,6 +764,13 @@ export class BridgeManager {
           // Check dynamic whitelist — auto-allow if previously approved
           if (this.permissions.isToolAllowed(toolName, toolInput)) {
             console.log(`[bridge] Auto-allowed ${toolName} via session whitelist`);
+            return 'allow' as const;
+          }
+
+          // Auto-allow if user just approved an AskUserQuestion
+          if (askQuestionApproved) {
+            askQuestionApproved = false;
+            console.log(`[bridge] Auto-allowed ${toolName} after AskUserQuestion approval`);
             return 'allow' as const;
           }
 
@@ -887,6 +898,9 @@ export class BridgeManager {
         }).catch(() => {});
         return { [q.question]: '' };
       }
+
+      // User answered — auto-allow the next tool permission in this query
+      askQuestionApproved = true;
 
       // Check for free text answer first, then option index
       const textAnswer = this.sdkQuestionTextAnswers.get(permId);


### PR DESCRIPTION
## Summary

- AskUserQuestion 被用户批准后，紧接着的工具权限请求自动放行
- 避免重复确认（如 Claude 问"要删除吗？"→ 用户点是 → Bash 权限又弹一次）
- 仅对同一查询中的下一次权限请求生效，之后重置

## Test plan

- [ ] 发送删除类指令，确认只弹一次确认（AskUserQuestion）而非两次
- [ ] 普通工具调用（无 AskUserQuestion 前置）仍正常弹权限