### PR TITLE
chore: remove coreVersion, use package version for Go binary downloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "tlive",
-  "version": "0.7.0",
-  "coreVersion": "0.5.0",
+  "version": "0.7.1",
   "description": "Terminal live monitoring + IM bridge for AI coding tools",
   "type": "module",
   "bin": {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -15,10 +15,9 @@ const PLATFORM_MAP = { linux: 'linux', darwin: 'darwin', win32: 'windows' };
 const ARCH_MAP = { x64: 'amd64', arm64: 'arm64' };
 
 function getVersion() {
-  // Use coreVersion if set, otherwise fall back to package version
   try {
     const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
-    return `v${pkg.coreVersion || pkg.version}`;
+    return `v${pkg.version}`;
   } catch {
     return 'latest';
   }


### PR DESCRIPTION
## Summary
- Remove `coreVersion` field from `package.json`
- Simplify `postinstall.js` to use `version` directly for Go binary downloads

`release-please` only bumps `version`, not `coreVersion`, causing them to drift apart. Since Go core binaries are always built and uploaded on every release, a separate `coreVersion` is unnecessary overhead.

## Test plan
- [x] `npm install` downloads correct Go binary version matching package version
- [x] Version check in `tlive --version` shows consistent version
- [x] Upgrade path: existing installs with `.core-version` file detect version change correctly