### PR TITLE
fix(bridge): convert <br> to newline for Telegram HTML mode

### DIFF
--- a/bridge/src/__tests__/markdown.test.ts
+++ b/bridge/src/__tests__/markdown.test.ts
@@ -21,6 +21,24 @@ describe('Telegram rendering', () => {
     // Telegram doesn't support <h1>, should be plain text or bold
     expect(result).not.toContain('<h1>');
   });
+
+  it('converts <br> from markdown hard break to newline', () => {
+    // CommonMark hard break: two trailing spaces before newline -> <br>
+    // Telegram HTML parse mode does NOT support <br> and rejects it with
+    // 400 Bad Request: can't parse entities: Unsupported start tag "br".
+    const result = markdownToTelegram('line one  \nline two');
+    expect(result).not.toContain('<br');
+    expect(result).toContain('line one');
+    expect(result).toContain('line two');
+  });
+
+  it('converts backslash hard break to newline', () => {
+    // CommonMark hard break: trailing backslash -> <br>
+    const result = markdownToTelegram('line one\\\nline two');
+    expect(result).not.toContain('<br');
+    expect(result).toContain('line one');
+    expect(result).toContain('line two');
+  });
 });
 
 describe('Discord chunking', () => {

--- a/bridge/src/markdown/ir.ts
+++ b/bridge/src/markdown/ir.ts
@@ -156,8 +156,12 @@ export function markdownToHtml(text: string): string {
   // Strip <hr> tags
   html = html.replace(/<hr\s*\/?>/g, '---\n');
 
-  // Strip any remaining unsupported HTML tags (keep: b, i, s, u, code, pre, a, br)
-  html = html.replace(/<\/?(?!b>|\/b>|i>|\/i>|s>|\/s>|u>|\/u>|code>|\/code>|pre>|\/pre>|a[\s>]|\/a>|br\s*\/?>)[a-z][a-z0-9]*[^>]*>/gi, '');
+  // <br> is NOT supported by Telegram HTML parse mode — convert to newline
+  // (Telegram API rejects <br> with 400: Unsupported start tag "br")
+  html = html.replace(/<br\s*\/?>/gi, '\n');
+
+  // Strip any remaining unsupported HTML tags (keep: b, i, s, u, code, pre, a)
+  html = html.replace(/<\/?(?!b>|\/b>|i>|\/i>|s>|\/s>|u>|\/u>|code>|\/code>|pre>|\/pre>|a[\s>]|\/a>)[a-z][a-z0-9]*[^>]*>/gi, '');
 
   return html.trim();
 }


### PR DESCRIPTION
## Problem

The Telegram Bot API's HTML parse mode **does not support the `<br>` tag** — it rejects any message containing `<br>` with:

```
400 Bad Request: can't parse entities: Unsupported start tag "br" at byte offset ...
```

However, `markdownToHtml` in `bridge/src/markdown/ir.ts` kept `<br>` in its whitelist of preserved tags, so any CommonMark **hard break** produced by `markdown-it` (trailing two spaces + newline, or trailing backslash + newline) was forwarded verbatim to Telegram.

The resulting `GrammyError` is thrown from `TelegramAdapter.editMessage` and propagates through `MessageRenderer.flushCallback` / `doFlush` without being caught, **crashing the entire bridge process** with an unhandled promise rejection.

### Stack trace observed in the wild

```
GrammyError: Call to 'editMessageText' failed! (400: Bad Request: can't parse entities: Unsupported start tag "br" at byte offset 476)
    at toGrammyError (.../grammy/out/core/error.js:47:12)
    at ApiClient.callApi (.../grammy/out/core/client.js:100:48)
    at async TelegramAdapter.editMessage (.../bridge/dist/main.mjs)
    at async MessageRenderer.flushCallback (.../bridge/dist/main.mjs)
    at async MessageRenderer.doFlush (.../bridge/dist/main.mjs)
Node.js v22.21.1
```

### Reproduction

Any IM message whose rendered markdown contains a hard line break triggers this — very easy to hit in practice when the model (especially Codex) emits multi-paragraph answers with forced line breaks. Minimal repro:

```ts
markdownToTelegram('line one  \nline two');
// -> "line one<br>\nline two"  (contains <br>, rejected by Telegram)
```

## Fix

In `bridge/src/markdown/ir.ts`:

1. **Replace `<br>` with a literal newline** before the whitelist strip.
2. **Remove `br` from the whitelist** (comment + regex) so it is never emitted again.

```diff
- // Strip any remaining unsupported HTML tags (keep: b, i, s, u, code, pre, a, br)
- html = html.replace(/<\/?(?!b>|\/b>|i>|\/i>|s>|\/s>|u>|\/u>|code>|\/code>|pre>|\/pre>|a[\s>]|\/a>|br\s*\/?>)[a-z][a-z0-9]*[^>]*>/gi, '');
+ // <br> is NOT supported by Telegram HTML parse mode — convert to newline
+ // (Telegram API rejects <br> with 400: Unsupported start tag "br")
+ html = html.replace(/<br\s*\/?>/gi, '\n');
+
+ // Strip any remaining unsupported HTML tags (keep: b, i, s, u, code, pre, a)
+ html = html.replace(/<\/?(?!b>|\/b>|i>|\/i>|s>|\/s>|u>|\/u>|code>|\/code>|pre>|\/pre>|a[\s>]|\/a>)[a-z][a-z0-9]*[^>]*>/gi, '');
```

Reference: [Telegram Bot API — HTML style](https://core.telegram.org/bots/api#html-style) lists the supported tags; `<br>` is not among them.

## Tests

Added two regression tests in `bridge/src/__tests__/markdown.test.ts` covering both CommonMark hard-break forms:

- `converts <br> from markdown hard break to newline` (trailing two spaces)
- `converts backslash hard break to newline` (trailing `\`)

Both pass locally. The rest of the `markdown.test.ts` suite continues to pass (19/19).

## Notes

- Scope intentionally minimal — only fixes the root cause in the markdown pipeline.
- A defensive follow-up (catching Telegram API parse errors in `TelegramAdapter.editMessage` / `sendMessage` and falling back to plain text) would further harden the bridge against any future unsupported-tag surprises, but is left out of this PR to keep the diff small and focused.