### PR TITLE
fix(bridge): harden editMessage against API errors (Telegram 429, Discord)

### DIFF
--- a/bridge/src/channels/discord.ts
+++ b/bridge/src/channels/discord.ts
@@ -269,39 +269,45 @@ export class DiscordAdapter extends BaseChannelAdapter {
   async editMessage(chatId: string, messageId: string, message: OutboundMessage): Promise<void> {
     if (!this.client) return;
 
-    // Use threadId if available, otherwise chatId
-    const targetId = message.threadId ?? chatId;
-    const channel = await this.client.channels.fetch(targetId) as TextChannel;
-    if (!channel || !channel.messages) return;
+    try {
+      // Use threadId if available, otherwise chatId
+      const targetId = message.threadId ?? chatId;
+      const channel = await this.client.channels.fetch(targetId) as TextChannel;
+      if (!channel || !channel.messages) return;
 
-    const existing = await channel.messages.fetch(messageId);
-    if (!existing) return;
+      const existing = await channel.messages.fetch(messageId);
+      if (!existing) return;
 
-    if (message.embed) {
-      const embed = new EmbedBuilder();
-      if (message.embed.title) embed.setTitle(message.embed.title);
-      if (message.embed.description) embed.setDescription(message.embed.description);
-      if (message.embed.color !== undefined) embed.setColor(message.embed.color);
-      if (message.embed.fields) {
-        for (const f of message.embed.fields) embed.addFields(f);
+      if (message.embed) {
+        const embed = new EmbedBuilder();
+        if (message.embed.title) embed.setTitle(message.embed.title);
+        if (message.embed.description) embed.setDescription(message.embed.description);
+        if (message.embed.color !== undefined) embed.setColor(message.embed.color);
+        if (message.embed.fields) {
+          for (const f of message.embed.fields) embed.addFields(f);
+        }
+        if (message.embed.footer) embed.setFooter({ text: message.embed.footer });
+        await existing.edit({ embeds: [embed] });
+        return;
       }
-      if (message.embed.footer) embed.setFooter({ text: message.embed.footer });
-      await existing.edit({ embeds: [embed] });
-      return;
+
+      const content = message.text ?? message.html ?? '';
+      const truncated = content.length > 2000 ? content.slice(0, 2000) : content;
+
+      const payload: Parameters<Message['edit']>[0] = { content: truncated };
+
+      if (message.buttons?.length) {
+        payload.components = DiscordAdapter.buildButtonRows(message.buttons);
+      } else if (message.buttons) {
+        payload.components = []; // clear existing buttons
+      }
+
+      await existing.edit(payload);
+    } catch (err: unknown) {
+      // Streaming edits are non-fatal: log and swallow so the bridge stays alive
+      const classified = classifyError('discord', err);
+      console.warn(`[discord] editMessage failed (${classified.constructor.name}): ${classified.message}`);
     }
-
-    const content = message.text ?? message.html ?? '';
-    const truncated = content.length > 2000 ? content.slice(0, 2000) : content;
-
-    const payload: Parameters<Message['edit']>[0] = { content: truncated };
-
-    if (message.buttons?.length) {
-      payload.components = DiscordAdapter.buildButtonRows(message.buttons);
-    } else if (message.buttons) {
-      payload.components = []; // clear existing buttons
-    }
-
-    await existing.edit(payload);
   }
 
   async sendTyping(chatId: string): Promise<void> {

--- a/bridge/src/channels/telegram.ts
+++ b/bridge/src/channels/telegram.ts
@@ -400,7 +400,35 @@ export class TelegramAdapter extends BaseChannelAdapter {
     try {
       await this.api.editMessageText(chatId, parseInt(messageId, 10), text, opts);
     } catch (err: unknown) {
-      if (!(err instanceof Error && err.message?.includes('message is not modified'))) throw err;
+      if (err instanceof Error && err.message?.includes('message is not modified')) return;
+
+      const classified = classifyError('telegram', err);
+
+      // 429 Rate limit: wait retry_after and retry once
+      if (classified.retryable && 'retryAfterMs' in classified) {
+        const delay = Math.min((classified as any).retryAfterMs || 1000, 30_000);
+        await new Promise(r => setTimeout(r, delay));
+        try {
+          await this.api.editMessageText(chatId, parseInt(messageId, 10), text, opts);
+          return;
+        } catch {
+          // give up — next flush will catch up
+        }
+      }
+
+      // 400 Format error: retry without HTML (same pattern as sendMessage)
+      if (!classified.retryable && opts.parse_mode) {
+        try {
+          delete opts.parse_mode;
+          await this.api.editMessageText(chatId, parseInt(messageId, 10), text, opts);
+          return;
+        } catch {
+          // give up
+        }
+      }
+
+      // Streaming edits are non-fatal: log and swallow so the bridge stays alive
+      console.warn(`[telegram] editMessage failed (${classified.constructor.name}): ${classified.message}`);
     }
   }
 

--- a/bridge/src/engine/message-renderer.ts
+++ b/bridge/src/engine/message-renderer.ts
@@ -296,7 +296,7 @@ export class MessageRenderer {
       try {
         result = await this.flushCallback(content, isEdit, flushButtons);
       } catch (err: any) {
-        // Retry once for transient network errors
+        // Retry once for transient / retryable errors
         const code = err?.code ?? '';
         const retryable = err?.retryable || ['ECONNRESET', 'ETIMEDOUT', 'EPIPE', 'UND_ERR_SOCKET'].includes(code);
         if (retryable) {
@@ -307,6 +307,8 @@ export class MessageRenderer {
             // give up after one retry
           }
         }
+        // Defense-in-depth: never let a flush error become an unhandled rejection.
+        // The next scheduled flush will catch up with the latest content.
       }
       if (!isEdit && typeof result === 'string') {
         this._messageId = result;
@@ -315,8 +317,13 @@ export class MessageRenderer {
       this.flushing = false;
       if (this.pendingFlush) {
         this.pendingFlush = false;
-        const retryContent = this.render();
-        if (retryContent) await this.doFlush(retryContent);
+        try {
+          const retryContent = this.render();
+          if (retryContent) await this.doFlush(retryContent);
+        } catch {
+          // Never let recursive flush errors propagate — the next scheduled
+          // flush will pick up the latest content.
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Closes #24

- **TelegramAdapter.editMessage**: classify errors via `classifyError`, retry once on 429 (honoring `retry_after`, capped at 30s), fall back to plain text on 400 format errors, log+swallow all other non-fatal errors
- **DiscordAdapter.editMessage**: wrap entire method in try/catch with log+swallow (consistent with FeishuAdapter which already does this)
- **MessageRenderer.doFlush**: wrap recursive flush in `finally` block with try/catch — this was the actual escape path where errors became unhandled rejections and crashed the process

## Root cause

`editMessage` only swallowed `message is not modified` and re-threw everything else. The raw `GrammyError` (no `.retryable` property) propagated through `doFlush`, whose retry logic only recognized network error codes (`ECONNRESET`, etc.). The error then escaped via the **unwrapped recursive `doFlush` call in the `finally` block**, becoming an unhandled rejection → `process.exit`.

Discord had the same class of bug: `editMessage` had zero error handling.

## Test plan

- [x] All 442 existing tests pass (1 pre-existing config.test.ts env failure unrelated)
- [x] Verified Telegram rejects `<br>` with 400 (covered by PR #23)
- [ ] Manual: trigger 429 by rapid streaming edits → bridge should log warning and continue
- [ ] Manual: Discord rate limit / permission error during edit → bridge stays alive