### PR TITLE
fix(bridge): mock config.env in config tests to avoid local env leaks

### DIFF
--- a/bridge/src/__tests__/config.test.ts
+++ b/bridge/src/__tests__/config.test.ts
@@ -1,5 +1,19 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { loadConfig } from '../config.js';
+
+// Prevent loadConfig from reading ~/.tlive/config.env so tests use pure defaults
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    readFileSync: vi.fn((path: string, ...args: any[]) => {
+      if (typeof path === 'string' && path.includes('config.env')) {
+        throw new Error('ENOENT');
+      }
+      return actual.readFileSync(path, ...args);
+    }),
+  };
+});
 
 describe('loadConfig', () => {
   const savedEnv = { ...process.env };


### PR DESCRIPTION
## Summary

`loadConfig()` reads `~/.tlive/config.env` at runtime. When a developer has a local config with `TL_PORT=7849` (or any non-default value), the "uses defaults when no env vars set" test fails because the env file value overrides the expected default of 8080.

Fix: mock `readFileSync` to throw `ENOENT` for `config.env` paths, so tests run with pure defaults regardless of the developer's local setup.

## Test plan

- [x] `config.test.ts` 7/7 pass on machine with local `~/.tlive/config.env`
- [x] Full suite 443/443 pass