### PR TITLE
fix: change default port from 8080 to 4590

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ tlive npm run build           # Wrap a build
 $ tlive claude --model opus
 
   TLive Web UI:
-    Local:   http://localhost:8080?token=abc123
-    Network: http://192.168.1.100:8080?token=abc123
+    Local:   http://localhost:4590?token=abc123
+    Network: http://192.168.1.100:4590?token=abc123
   Session: claude (ID: a1b2c3)
 ```
 
@@ -196,7 +196,7 @@ tlive hooks resume         # Resume hooks (IM approval)
 Single config file `~/.tlive/config.env` (created by `tlive setup`):
 
 ```env
-TL_PORT=8080
+TL_PORT=4590
 TL_TOKEN=auto-generated
 TL_HOST=0.0.0.0
 TL_PUBLIC_URL=https://example.com
@@ -232,7 +232,7 @@ See [config.env.example](config.env.example) for all options.
 
 To access the web terminal from outside your LAN (e.g. via frpc, Cloudflare Tunnel, ngrok):
 
-1. Forward local port `8080` (or your `TL_PORT`) through the tunnel
+1. Forward local port `4590` (or your `TL_PORT`) through the tunnel
 2. Set `TL_PUBLIC_URL` to your tunnel domain:
    ```env
    TL_PUBLIC_URL=https://your-domain.com

--- a/README_CN.md
+++ b/README_CN.md
@@ -53,8 +53,8 @@ tlive npm run build           # 包装构建
 $ tlive claude --model opus
 
   TLive Web UI:
-    Local:   http://localhost:8080?token=abc123
-    Network: http://192.168.1.100:8080?token=abc123
+    Local:   http://localhost:4590?token=abc123
+    Network: http://192.168.1.100:4590?token=abc123
   Session: claude (ID: a1b2c3)
 ```
 
@@ -185,7 +185,7 @@ tlive hooks resume         # 恢复 Hook（IM 审批）
 统一配置文件 `~/.tlive/config.env`（由 `tlive setup` 创建）：
 
 ```env
-TL_PORT=8080
+TL_PORT=4590
 TL_TOKEN=自动生成
 TL_HOST=0.0.0.0
 TL_PUBLIC_URL=https://example.com
@@ -207,7 +207,7 @@ TL_FS_APP_SECRET=...
 
 通过 frpc、Cloudflare Tunnel、ngrok 等从外网访问 web terminal：
 
-1. 将本地 `8080` 端口（或你的 `TL_PORT`）通过隧道转发
+1. 将本地 `4590` 端口（或你的 `TL_PORT`）通过隧道转发
 2. 设置 `TL_PUBLIC_URL` 为隧道域名：
    ```env
    TL_PUBLIC_URL=https://your-domain.com

--- a/SKILL.md
+++ b/SKILL.md
@@ -89,7 +89,7 @@ Enter numbers (e.g., 1,3):"
 
 **Step 3 — General settings:**
 - Runtime: claude (default) or codex
-- Port (default 8080)
+- Port (default 4590)
 - Public URL (optional, for web links in IM messages)
 - Auto-generate TL_TOKEN (32-char hex)
 

--- a/bridge/src/__tests__/config.test.ts
+++ b/bridge/src/__tests__/config.test.ts
@@ -17,9 +17,9 @@ describe('loadConfig', () => {
 
   it('uses defaults when no env vars set', () => {
     const config = loadConfig();
-    expect(config.port).toBe(8080);
+    expect(config.port).toBe(4590);
     expect(config.runtime).toBe('claude');
-    expect(config.coreUrl).toBe('http://localhost:8080');
+    expect(config.coreUrl).toBe('http://localhost:4590');
   });
 
   it('loads from env vars', () => {

--- a/bridge/src/__tests__/core-client.test.ts
+++ b/bridge/src/__tests__/core-client.test.ts
@@ -18,7 +18,7 @@ beforeAll(async () => {
 
     if (req.method === 'GET' && url.pathname === '/api/status') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ status: 'running', uptime: 10, port: 8080, sessions: 1, version: '0.1.0' }));
+      res.end(JSON.stringify({ status: 'running', uptime: 10, port: 4590, sessions: 1, version: '0.1.0' }));
     } else if (req.method === 'GET' && url.pathname === '/api/sessions') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify([{ id: 'sess1', command: 'bash', status: 'running' }]));

--- a/bridge/src/__tests__/formatting.test.ts
+++ b/bridge/src/__tests__/formatting.test.ts
@@ -74,11 +74,11 @@ describe('formatNotification', () => {
 
   it('stop: telegram with localhost uses inline text link', () => {
     const msg = formatNotification(
-      { type: 'stop', title: 'Done', summary: 'ok', terminalUrl: 'http://localhost:8080/t' },
+      { type: 'stop', title: 'Done', summary: 'ok', terminalUrl: 'http://localhost:4590/t' },
       'telegram'
     );
     expect(msg.html).toContain('Open Terminal');
-    expect(msg.html).toContain('localhost:8080');
+    expect(msg.html).toContain('localhost:4590');
     expect((msg as any).buttons).toBeUndefined();
   });
 

--- a/bridge/src/__tests__/permission-coordinator.test.ts
+++ b/bridge/src/__tests__/permission-coordinator.test.ts
@@ -10,7 +10,7 @@ describe('PermissionCoordinator', () => {
 
   beforeEach(() => {
     gateway = new PendingPermissions();
-    broker = new PermissionBroker(gateway, 'http://localhost:8080');
+    broker = new PermissionBroker(gateway, 'http://localhost:4590');
     coord = new PermissionCoordinator(gateway, broker, 'http://localhost:9090', 'test-token');
   });
 

--- a/bridge/src/config.ts
+++ b/bridge/src/config.ts
@@ -106,7 +106,7 @@ export function loadConfig(): Config {
   const get = (key: string, defaultValue = ''): string =>
     process.env[key] ?? envFile[key] ?? defaultValue;
 
-  const port = parseInt(get('TL_PORT', '8080'), 10);
+  const port = parseInt(get('TL_PORT', '4590'), 10);
   const globalProxy = get('TL_PROXY');
 
   const config: Config = {

--- a/bridge/src/engine/bridge-manager.ts
+++ b/bridge/src/engine/bridge-manager.ts
@@ -89,7 +89,7 @@ export class BridgeManager {
 
   constructor() {
     const config = loadConfig();
-    const effectivePublicUrl = config.publicUrl || `http://${getLocalIP()}:${config.port || 8080}`;
+    const effectivePublicUrl = config.publicUrl || `http://${getLocalIP()}:${config.port || 4590}`;
     const gateway = new PendingPermissions();
     const broker = new PermissionBroker(gateway, effectivePublicUrl);
     this.coreUrl = config.coreUrl;
@@ -234,7 +234,7 @@ export class BridgeManager {
     let terminalUrl: string | undefined;
     if (this.coreAvailable && hook.tlive_session_id) {
       const config = loadConfig();
-      const baseUrl = config.publicUrl || `http://${getLocalIP()}:${config.port || 8080}`;
+      const baseUrl = config.publicUrl || `http://${getLocalIP()}:${config.port || 4590}`;
       terminalUrl = `${baseUrl}/terminal.html?id=${hook.tlive_session_id}&token=${this.token}`;
     }
 

--- a/bridge/src/setup-wizard.ts
+++ b/bridge/src/setup-wizard.ts
@@ -71,7 +71,7 @@ export async function runSetupWizard(): Promise<void> {
   if (isUpdate) {
     console.log(`Existing config: ${CONFIG_PATH}`);
     console.log(`  Channels: ${existing.TL_ENABLED_CHANNELS || '(none)'}`);
-    console.log(`  Port: ${existing.TL_PORT || '8080'}`);
+    console.log(`  Port: ${existing.TL_PORT || '4590'}`);
     console.log('');
 
     const mode = await ask('What do you want to do?\n  1. Update existing config\n  2. Start fresh\n  3. Cancel\nChoice', '1');
@@ -86,7 +86,7 @@ export async function runSetupWizard(): Promise<void> {
 
   // Token + port
   if (!config.TL_TOKEN) config.TL_TOKEN = randomBytes(16).toString('hex');
-  config.TL_PORT = await ask('Web server port', config.TL_PORT || '8080');
+  config.TL_PORT = await ask('Web server port', config.TL_PORT || '4590');
 
   // Choose platforms
   const currentChannels = (config.TL_ENABLED_CHANNELS || '').split(',').filter(Boolean);

--- a/core/cmd/tlive/main.go
+++ b/core/cmd/tlive/main.go
@@ -21,7 +21,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.PersistentFlags().IntVarP(&port, "port", "p", 8080, "Web server port")
+	rootCmd.PersistentFlags().IntVarP(&port, "port", "p", 4590, "Web server port")
 	rootCmd.PersistentFlags().StringVar(&token, "token", "", "Auth token")
 	rootCmd.Flags().StringVar(&publicIP, "ip", "", "Override auto-detected LAN IP address")
 	// Stop parsing flags after the first positional arg (the wrapped command).

--- a/core/internal/config/config.go
+++ b/core/internal/config/config.go
@@ -24,7 +24,7 @@ type DaemonConfig struct {
 func Default() *Config {
 	return &Config{
 		Daemon: DaemonConfig{
-			Port: 8080,
+			Port: 4590,
 			Host: "0.0.0.0",
 		},
 	}

--- a/core/internal/config/config_test.go
+++ b/core/internal/config/config_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestDefault(t *testing.T) {
 	cfg := Default()
-	if cfg.Daemon.Port != 8080 {
-		t.Errorf("expected default port 8080, got %d", cfg.Daemon.Port)
+	if cfg.Daemon.Port != 4590 {
+		t.Errorf("expected default port 4590, got %d", cfg.Daemon.Port)
 	}
 	if cfg.Daemon.Host != "0.0.0.0" {
 		t.Errorf("expected default host 0.0.0.0, got %s", cfg.Daemon.Host)
@@ -26,8 +26,8 @@ func TestLoadFromEnv_Missing(t *testing.T) {
 	if err != nil {
 		t.Fatal("missing config.env should return defaults, not error:", err)
 	}
-	if cfg.Daemon.Port != 8080 {
-		t.Errorf("expected default port 8080, got %d", cfg.Daemon.Port)
+	if cfg.Daemon.Port != 4590 {
+		t.Errorf("expected default port 4590, got %d", cfg.Daemon.Port)
 	}
 }
 

--- a/core/internal/daemon/daemon_test.go
+++ b/core/internal/daemon/daemon_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDaemon_StatusEndpoint(t *testing.T) {
-	d := NewDaemon(DaemonConfig{Port: 8080, Token: "t"})
+	d := NewDaemon(DaemonConfig{Port: 4590, Token: "t"})
 	handler := d.Handler()
 
 	req := httptest.NewRequest("GET", "/api/status", nil)

--- a/core/internal/daemon/lockfile_test.go
+++ b/core/internal/daemon/lockfile_test.go
@@ -10,7 +10,7 @@ func TestLockFile_WriteAndRead(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "daemon.json")
 
-	info := LockInfo{Port: 8080, Token: "abc123", Pid: 12345}
+	info := LockInfo{Port: 4590, Token: "abc123", Pid: 12345}
 	if err := WriteLockFile(path, info); err != nil {
 		t.Fatalf("WriteLockFile: %v", err)
 	}
@@ -19,7 +19,7 @@ func TestLockFile_WriteAndRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadLockFile: %v", err)
 	}
-	if got.Port != 8080 || got.Token != "abc123" || got.Pid != 12345 {
+	if got.Port != 4590 || got.Token != "abc123" || got.Pid != 12345 {
 		t.Errorf("unexpected lock info: %+v", got)
 	}
 }
@@ -35,7 +35,7 @@ func TestLockFile_Remove(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "daemon.json")
 
-	info := LockInfo{Port: 8080, Token: "t", Pid: 1}
+	info := LockInfo{Port: 4590, Token: "t", Pid: 1}
 	WriteLockFile(path, info)
 	RemoveLockFile(path)
 

--- a/docs/getting-started-cn.md
+++ b/docs/getting-started-cn.md
@@ -76,7 +76,7 @@ TL_TG_BOT_TOKEN=7823456789:AAF-xxxxx
 TL_TG_CHAT_ID=123456789
 
 # Web 终端端口和访问令牌
-TL_PORT=8080
+TL_PORT=4590
 TL_TOKEN=your-secret-token
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,7 +76,7 @@ TL_TG_BOT_TOKEN=7823456789:AAF-xxxxx
 TL_TG_CHAT_ID=123456789
 
 # Web terminal port and access token
-TL_PORT=8080
+TL_PORT=4590
 TL_TOKEN=your-secret-token
 ```
 

--- a/references/troubleshooting.md
+++ b/references/troubleshooting.md
@@ -36,7 +36,7 @@
 **Steps**:
 1. Verify hooks are configured in `~/.claude/settings.json`
 2. Check hook scripts exist: `ls -la ~/.tlive/bin/hook-handler.sh`
-3. Check Go Core is running: `curl -sf http://localhost:8080/api/status`
+3. Check Go Core is running: `curl -sf http://localhost:4590/api/status`
 4. Check hooks aren't paused: `tlive hooks`
 5. Test hook script manually: `echo '{}' | ~/.tlive/bin/hook-handler.sh`
 

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -153,7 +153,7 @@ async function daemonStatus() {
   }
 
   // Check Go Core web terminal
-  const port = process.env.TL_PORT || config.TL_PORT || '8080';
+  const port = process.env.TL_PORT || config.TL_PORT || '4590';
   const token = process.env.TL_TOKEN || config.TL_TOKEN || '';
   try {
     const resp = await fetch(`http://localhost:${port}/api/status`, {
@@ -307,7 +307,7 @@ async function runDoctor() {
 
   // API check
   const config = existsSync(CONFIG_FILE) ? loadConfigEnv() : {};
-  const port = process.env.TL_PORT || config.TL_PORT || '8080';
+  const port = process.env.TL_PORT || config.TL_PORT || '4590';
   const token = process.env.TL_TOKEN || config.TL_TOKEN || '';
   try {
     const resp = await fetch(`http://localhost:${port}/api/status`, {

--- a/scripts/hook-handler.mjs
+++ b/scripts/hook-handler.mjs
@@ -24,7 +24,7 @@ hookJson.tlive_session_id = sessionId;
 hookJson.tlive_cwd = process.cwd();
 
 // Load config
-let port = '8080';
+let port = '4590';
 let token = '';
 const configPath = join(homedir(), '.tlive', 'config.env');
 if (existsSync(configPath)) {

--- a/scripts/notify-handler.mjs
+++ b/scripts/notify-handler.mjs
@@ -28,7 +28,7 @@ hookJson.tlive_hook_type = 'notification';
 hookJson.tlive_cwd = process.cwd();
 
 // Load config
-let port = '8080';
+let port = '4590';
 let token = '';
 const configPath = join(homedir(), '.tlive', 'config.env');
 if (existsSync(configPath)) {

--- a/scripts/statusline.mjs
+++ b/scripts/statusline.mjs
@@ -14,7 +14,7 @@ let sessionJson = '';
 for await (const chunk of process.stdin) sessionJson += chunk;
 
 // Load config
-let port = '8080';
+let port = '4590';
 let token = '';
 const configPath = join(home, '.tlive', 'config.env');
 if (existsSync(configPath)) {

--- a/scripts/stop-handler.mjs
+++ b/scripts/stop-handler.mjs
@@ -25,7 +25,7 @@ hookJson.tlive_hook_type = 'stop';
 hookJson.tlive_cwd = process.cwd();
 
 // Load config
-let port = '8080';
+let port = '4590';
 let token = '';
 const configPath = join(homedir(), '.tlive', 'config.env');
 if (existsSync(configPath)) {


### PR DESCRIPTION
## Summary

Port 8080 is commonly used by dev servers, proxies, and other tools (e.g. WeChat on macOS), causing conflicts when running tlive. Switch to port 4590 which has no known service conflicts.

Changes are purely value replacements across code, tests, and docs — zero architecture changes.

Users with `TL_PORT` in `config.env` are unaffected.

## Test plan

- [x] Go tests pass
- [x] Bridge 443/443 tests pass
- [x] Local `tlive claude` shows port 4590