### PR TITLE
fix(bridge): remove abort signal and timeout for SDK permissions

### DIFF
--- a/bridge/src/engine/bridge-manager.ts
+++ b/bridge/src/engine/bridge-manager.ts
@@ -885,7 +885,7 @@ export class BridgeManager {
     // Build SDK-level permission handler based on /perm mode
     const permMode = this.state.getPermMode(msg.channelType, msg.chatId);
     const sdkPermissionHandler = permMode === 'on'
-      ? async (toolName: string, toolInput: Record<string, unknown>, promptSentence: string, signal?: AbortSignal) => {
+      ? async (toolName: string, toolInput: Record<string, unknown>, promptSentence: string, _signal?: AbortSignal) => {
           // Check dynamic whitelist — auto-allow if previously approved
           if (this.permissions.isToolAllowed(toolName, toolInput)) {
             console.log(`[bridge] Auto-allowed ${toolName} via session whitelist`);
@@ -904,15 +904,9 @@ export class BridgeManager {
           this.permissions.setPendingSdkPerm(chatKey, permId);
           console.log(`[bridge] Permission request: ${toolName} (${permId}) for ${chatKey}`);
 
-          // If SDK aborts (subagent stopped), clean up gateway entry and remove from queue
-          const abortCleanup = () => {
-            console.log(`[bridge] Permission cancelled by SDK: ${toolName} (${permId})`);
-            this.permissions.getGateway().resolve(permId, 'deny', 'Cancelled by SDK');
-            this.permissions.clearPendingSdkPerm(chatKey);
-            renderer.onPermissionResolved(permId);
-          };
-          if (signal?.aborted) { abortCleanup(); return 'deny' as const; }
-          signal?.addEventListener('abort', abortCleanup, { once: true });
+          // NOTE: We intentionally ignore the SDK abort signal for IM permissions.
+          // IM users may respond hours later — the abort signal should not auto-deny
+          // a permission the user hasn't seen yet. No timeout either.
 
           // Render permission inline in the terminal card
           const inputStr = getToolCommand(toolName, toolInput)
@@ -923,15 +917,8 @@ export class BridgeManager {
           ];
           renderer.onPermissionNeeded(toolName, inputStr, permId, buttons);
 
-          // Wait for user response (5 min timeout)
-          const result = await this.permissions.getGateway().waitFor(permId, {
-            timeoutMs: 5 * 60 * 1000,
-            onTimeout: () => {
-              this.permissions.clearPendingSdkPerm(chatKey);
-              console.warn(`[bridge] Permission timeout: ${toolName} (${permId})`);
-            },
-          });
-          signal?.removeEventListener('abort', abortCleanup);
+          // Wait for user response — no timeout, IM users may respond much later
+          const result = await this.permissions.getGateway().waitFor(permId);
           renderer.onPermissionResolved(permId);
 
           // Update timeout reminder message if it was sent
@@ -954,7 +941,7 @@ export class BridgeManager {
     // Build SDK-level AskUserQuestion handler
     const sdkAskQuestionHandler = async (
       questions: Array<{ question: string; header: string; options: Array<{ label: string; description?: string }>; multiSelect: boolean }>,
-      signal?: AbortSignal,
+      _signal?: AbortSignal,
     ): Promise<Record<string, string>> => {
       if (!questions.length) return {};
       const q = questions[0];
@@ -998,16 +985,9 @@ export class BridgeManager {
 
       // Create gateway entry BEFORE sending — prevents race condition where user
       // replies before waitFor is called, causing isPending() to return false
-      const abortCleanup = () => {
-        this.permissions.getGateway().resolve(permId, 'deny', 'Cancelled');
-        this.sdkQuestionData.delete(permId);
-      };
-      if (signal?.aborted) { abortCleanup(); throw new Error('Cancelled'); }
-      signal?.addEventListener('abort', abortCleanup, { once: true });
-      const waitPromise = this.permissions.getGateway().waitFor(permId, {
-        timeoutMs: 5 * 60 * 1000,
-        onTimeout: () => { this.sdkQuestionData.delete(permId); },
-      });
+      // NOTE: We intentionally ignore the abort signal for AskUserQuestion.
+      // IM users may respond hours later — questions must wait for user response.
+      const waitPromise = this.permissions.getGateway().waitFor(permId);
 
       // Send question card AFTER gateway entry exists — user replies are now safe
       const hint = isMulti
@@ -1024,9 +1004,8 @@ export class BridgeManager {
       const sendResult = await adapter.send(outMsg);
       this.permissions.trackPermissionMessage(sendResult.messageId, permId, binding.sessionId, msg.channelType);
 
-      // Await user answer
+      // Await user answer — waits indefinitely until user responds via IM
       const result = await waitPromise;
-      signal?.removeEventListener('abort', abortCleanup);
 
       if (result.behavior === 'deny') {
         this.sdkQuestionData.delete(permId);

--- a/bridge/src/providers/claude-sdk.ts
+++ b/bridge/src/providers/claude-sdk.ts
@@ -232,6 +232,9 @@ export class ClaudeSDKProvider implements LLMProvider {
                 options: { decisionReason?: string; title?: string; suggestions?: unknown[]; signal?: AbortSignal } = {},
               ): Promise<PermissionResult> => {
                 // AskUserQuestion — route to dedicated handler
+                // NOTE: We intentionally do NOT pass the abort signal to the IM handler.
+                // IM users may respond hours later; the SDK's abort signal should not
+                // cancel a question the user hasn't even seen yet.
                 if (toolName === 'AskUserQuestion' && params.onAskUserQuestion) {
                   const questions = (input as Record<string, unknown>).questions as Array<{
                     question: string;
@@ -241,7 +244,7 @@ export class ClaudeSDKProvider implements LLMProvider {
                   }> ?? [];
                   if (questions.length > 0) {
                     try {
-                      const answers = await params.onAskUserQuestion(questions, options.signal);
+                      const answers = await params.onAskUserQuestion(questions);
                       return {
                         behavior: 'allow' as const,
                         updatedInput: { questions: (input as Record<string, unknown>).questions, answers },
@@ -255,14 +258,13 @@ export class ClaudeSDKProvider implements LLMProvider {
                 if (!params.onPermissionRequest) {
                   return { behavior: 'allow' as const, updatedInput: input };
                 }
-                // Already aborted by SDK (subagent stopped) → don't bother asking
-                if (options.signal?.aborted) {
-                  return { behavior: 'deny' as const, message: 'Cancelled by SDK' };
-                }
+                // NOTE: We intentionally ignore options.signal?.aborted here.
+                // In IM context, the user may not be at the keyboard — the abort signal
+                // should not auto-deny a permission the user hasn't seen yet.
                 const reason = options.decisionReason || options.title || toolName;
                 console.log(`[claude-sdk] canUseTool: ${toolName} → asking user (${reason})`);
-                // Pass abort signal so handler can clean up gateway entry on cancel
-                const decision = await params.onPermissionRequest(toolName, input, reason, options.signal);
+                // Do not pass abort signal — IM permissions wait indefinitely for user response
+                const decision = await params.onPermissionRequest(toolName, input, reason);
                 if (decision === 'allow') {
                   return { behavior: 'allow' as const, updatedInput: input };
                 }


### PR DESCRIPTION
## Summary

- Remove SDK abort signal handling from permission requests and AskUserQuestion in IM bridge
- Remove 5-minute timeout — IM users may respond hours or days later
- Fix race condition where SDK abort could deny permissions before they reach the user

## Problem

In SDK mode, the `canUseTool` callback receives an `AbortSignal` from the SDK. When the SDK cancels a request (e.g., subagent stopped, query ended), the abort handler immediately resolves permissions as "deny" and skips AskUserQuestion — before the user even sees the card on Telegram/Discord/Feishu.

The 5-minute timeout also prematurely denies permissions for IM users who are away from their phone.

## Changes

**`bridge/src/providers/claude-sdk.ts`**
- Don't pass `signal` to `onAskUserQuestion` handler
- Don't check `signal.aborted` before forwarding permission requests
- Don't pass `signal` to `onPermissionRequest` handler

**`bridge/src/engine/bridge-manager.ts`**  
- `sdkPermissionHandler`: remove abort listener + cleanup, remove 5-min timeout
- `sdkAskQuestionHandler`: remove abort listener + cleanup, remove 5-min timeout
- Both now wait indefinitely for user response via IM

## Rationale

The official SDK docs describe the abort signal as just "a cancellation signal" — not mandatory to honor. The SDK doesn't even use it yet. In IM context, the user controls when to respond; the SDK should not make that decision.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 443 tests passed
- [x] Manual: trigger permission request via IM, verify no timeout
- [x] Manual: trigger AskUserQuestion via IM, verify no abort