### PR TITLE
feat(bridge): /menu control panel with button-based UI

### DIFF
--- a/bridge/src/__tests__/control-panel.test.ts
+++ b/bridge/src/__tests__/control-panel.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ControlPanel } from '../engine/control-panel.js';
+import type { BaseChannelAdapter } from '../channels/base.js';
+import type { SessionStateManager } from '../engine/session-state.js';
+import type { SDKEngine } from '../engine/sdk-engine.js';
+import type { ChannelRouter } from '../engine/router.js';
+import type { QueryControls } from '../providers/base.js';
+import type { OutboundMessage } from '../channels/types.js';
+
+function mockAdapter(channelType = 'telegram'): BaseChannelAdapter {
+  return {
+    channelType,
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    consumeOne: vi.fn().mockResolvedValue(null),
+    send: vi.fn().mockResolvedValue({ messageId: 'msg1', success: true }),
+    editMessage: vi.fn().mockResolvedValue(undefined),
+    sendTyping: vi.fn().mockResolvedValue(undefined),
+    validateConfig: vi.fn().mockReturnValue(null),
+    isAuthorized: vi.fn().mockReturnValue(true),
+  } as any;
+}
+
+function mockState(): SessionStateManager {
+  return {
+    getModel: vi.fn().mockReturnValue(undefined),
+    getEffort: vi.fn().mockReturnValue(undefined),
+    getPermMode: vi.fn().mockReturnValue('on'),
+    getRuntime: vi.fn().mockReturnValue(undefined),
+    setModel: vi.fn(),
+    setEffort: vi.fn(),
+    setPermMode: vi.fn(),
+    clearLastActive: vi.fn(),
+    clearThread: vi.fn(),
+    stateKey: vi.fn().mockImplementation((ct: string, id: string) => `${ct}:${id}`),
+  } as any;
+}
+
+function mockSdkEngine(): SDKEngine {
+  return {
+    getCostTracker: vi.fn().mockReturnValue(null),
+  } as any;
+}
+
+function mockRouter(): ChannelRouter {
+  return {
+    resolve: vi.fn().mockResolvedValue({ sessionId: 'current-session' }),
+    rebind: vi.fn().mockResolvedValue({}),
+  } as any;
+}
+
+describe('ControlPanel', () => {
+  let panel: ControlPanel;
+  let state: ReturnType<typeof mockState>;
+  let sdkEngine: ReturnType<typeof mockSdkEngine>;
+  let router: ReturnType<typeof mockRouter>;
+  let controls: Map<string, QueryControls>;
+  let onNewSession: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    state = mockState();
+    sdkEngine = mockSdkEngine();
+    router = mockRouter();
+    controls = new Map();
+    onNewSession = vi.fn();
+    panel = new ControlPanel(state as any, sdkEngine as any, controls, router as any, onNewSession);
+  });
+
+  describe('buildMainPanel', () => {
+    it('returns card with 6 buttons for telegram', () => {
+      const msg = panel.buildMainPanel('telegram', 'chat1');
+      expect(msg.chatId).toBe('chat1');
+      expect(msg.html).toContain('TLive');
+      expect(msg.buttons).toHaveLength(6);
+
+      const labels = msg.buttons!.map(b => b.label);
+      expect(labels).toContain('🤖 Model');
+      expect(labels).toContain('📋 Sessions');
+      expect(labels).toContain('⏹ Stop');
+      expect(labels).toContain('📊 Stats');
+    });
+
+    it('returns embed with fields for discord', () => {
+      const msg = panel.buildMainPanel('discord', 'chat1');
+      expect(msg.embed?.title).toBe('⚙️ TLive');
+      expect(msg.embed?.color).toBe(0x3399FF);
+      expect(msg.embed?.fields).toBeDefined();
+      expect(msg.embed?.fields?.length).toBeGreaterThanOrEqual(4);
+      expect(msg.buttons).toHaveLength(6);
+    });
+
+    it('returns feishu card', () => {
+      const msg = panel.buildMainPanel('feishu', 'chat1');
+      expect(msg.feishuHeader?.title).toBe('⚙️ TLive');
+      expect(msg.feishuHeader?.template).toBe('blue');
+      expect(msg.buttons).toHaveLength(6);
+    });
+
+    it('reflects current state values', () => {
+      (state.getModel as any).mockReturnValue('claude-opus-4-6');
+      (state.getEffort as any).mockReturnValue('high');
+      (state.getPermMode as any).mockReturnValue('off');
+      (state.getRuntime as any).mockReturnValue('codex');
+
+      const msg = panel.buildMainPanel('telegram', 'chat1');
+      expect(msg.html).toContain('claude-opus-4-6');
+      expect(msg.html).toContain('high');
+      expect(msg.html).toContain('OFF');
+      expect(msg.html).toContain('codex');
+    });
+  });
+
+  describe('show', () => {
+    it('sends main panel via adapter', async () => {
+      const adapter = mockAdapter();
+      await panel.show(adapter, 'chat1');
+      expect(adapter.send).toHaveBeenCalledTimes(1);
+      const sent = (adapter.send as any).mock.calls[0][0] as OutboundMessage;
+      expect(sent.buttons).toHaveLength(6);
+    });
+  });
+
+  describe('handleCallback', () => {
+    it('model shows model picker', async () => {
+      const adapter = mockAdapter();
+      await panel.handleCallback(adapter, 'chat1', 'msg1', 'model:telegram:chat1');
+      expect(adapter.editMessage).toHaveBeenCalledTimes(1);
+      const edited = (adapter.editMessage as any).mock.calls[0][2] as OutboundMessage;
+      expect(edited.html).toContain('Select Model');
+    });
+
+    it('model select updates state and returns to main panel', async () => {
+      const adapter = mockAdapter();
+      await panel.handleCallback(adapter, 'chat1', 'msg1', 'model:select:claude-opus-4-6:telegram:chat1');
+      expect(state.setModel).toHaveBeenCalledWith('telegram', 'chat1', 'claude-opus-4-6');
+      const edited = (adapter.editMessage as any).mock.calls[0][2] as OutboundMessage;
+      expect(edited.html).toContain('⚙️ TLive');
+    });
+
+    it('model select default resets model', async () => {
+      const adapter = mockAdapter();
+      await panel.handleCallback(adapter, 'chat1', 'msg1', 'model:select:default:telegram:chat1');
+      expect(state.setModel).toHaveBeenCalledWith('telegram', 'chat1', undefined);
+    });
+
+    it('effort shows effort picker', async () => {
+      const adapter = mockAdapter();
+      await panel.handleCallback(adapter, 'chat1', 'msg1', 'effort:telegram:chat1');
+      const edited = (adapter.editMessage as any).mock.calls[0][2] as OutboundMessage;
+      expect(edited.html).toContain('Select Effort');
+    });
+
+    it('effort select updates state and returns to main', async () => {
+      const adapter = mockAdapter();
+      await panel.handleCallback(adapter, 'chat1', 'msg1', 'effort:select:high:telegram:chat1');
+      expect(state.setEffort).toHaveBeenCalledWith('telegram', 'chat1', 'high');
+    });
+
+    it('perm toggles permission mode', async () => {
+      const adapter = mockAdapter();
+      (state.getPermMode as any).mockReturnValue('on');
+      await panel.handleCallback(adapter, 'chat1', 'msg1', 'perm:telegram:chat1');
+      expect(state.setPermMode).toHaveBeenCalledWith('telegram', 'chat1', 'off');
+    });
+
+    it('perm toggle off→on', async () => {
+      const adapter = mockAdapter();
+      (state.getPermMode as any).mockReturnValue('off');
+      await panel.handleCallback(adapter, 'chat1', 'msg1', 'perm:telegram:chat1');
+      expect(state.setPermMode).toHaveBeenCalledWith('telegram', 'chat1', 'on');
+    });
+
+    it('stop interrupts active query', async () => {
+      const adapter = mockAdapter();
+      const ctrl = { interrupt: vi.fn().mockResolvedValue(undefined), stopTask: vi.fn() };
+      controls.set('telegram:chat1', ctrl);
+      await panel.handleCallback(adapter, 'chat1', 'msg1', 'stop:telegram:chat1');
+      expect(ctrl.interrupt).toHaveBeenCalled();
+      expect(controls.has('telegram:chat1')).toBe(false);
+    });
+
+    it('stats shows stats card', async () => {
+      const adapter = mockAdapter();
+      await panel.handleCallback(adapter, 'chat1', 'msg1', 'stats:telegram:chat1');
+      const edited = (adapter.editMessage as any).mock.calls[0][2] as OutboundMessage;
+      expect(edited.html).toContain('Session Stats');
+    });
+
+    it('back returns to main panel', async () => {
+      const adapter = mockAdapter();
+      await panel.handleCallback(adapter, 'chat1', 'msg1', 'back:telegram:chat1');
+      const edited = (adapter.editMessage as any).mock.calls[0][2] as OutboundMessage;
+      expect(edited.html).toContain('⚙️ TLive');
+    });
+  });
+
+  describe('buildModelPicker', () => {
+    it('shows claude models by default', () => {
+      const msg = panel.buildModelPicker('telegram', 'chat1');
+      expect(msg.html).toContain('Select Model');
+      const labels = msg.buttons!.map(b => b.label);
+      expect(labels).toContain('claude-sonnet-4-6');
+      expect(labels).toContain('claude-opus-4-6');
+      expect(labels).toContain('claude-haiku-4-5');
+      expect(labels).toContain('↩ Back');
+    });
+
+    it('shows codex models for codex runtime', () => {
+      (state.getRuntime as any).mockReturnValue('codex');
+      const msg = panel.buildModelPicker('telegram', 'chat1');
+      const labels = msg.buttons!.map(b => b.label);
+      expect(labels).toContain('codex-mini');
+      expect(labels).toContain('o4-mini');
+    });
+
+    it('marks current model with checkmark', () => {
+      (state.getModel as any).mockReturnValue('claude-opus-4-6');
+      const msg = panel.buildModelPicker('telegram', 'chat1');
+      const opusBtn = msg.buttons!.find(b => b.label.includes('claude-opus-4-6'));
+      expect(opusBtn?.label).toBe('✓ claude-opus-4-6');
+      expect(opusBtn?.style).toBe('primary');
+    });
+  });
+
+  describe('buildEffortPicker', () => {
+    it('shows 4 effort levels + back', () => {
+      const msg = panel.buildEffortPicker('telegram', 'chat1');
+      expect(msg.buttons).toHaveLength(5);
+      const labels = msg.buttons!.map(b => b.label);
+      expect(labels).toContain('⚡ Low');
+      expect(labels).toContain('🧠 Medium');
+      expect(labels).toContain('💪 High');
+      expect(labels).toContain('🔥 Max');
+      expect(labels).toContain('↩ Back');
+    });
+
+    it('marks current effort with checkmark', () => {
+      (state.getEffort as any).mockReturnValue('high');
+      const msg = panel.buildEffortPicker('telegram', 'chat1');
+      const highBtn = msg.buttons!.find(b => b.label.includes('High'));
+      expect(highBtn?.label).toBe('💪 High ✓');
+      expect(highBtn?.style).toBe('primary');
+    });
+  });
+
+  describe('buildStatsCard', () => {
+    it('shows "no stats" when no tracker', () => {
+      const msg = panel.buildStatsCard('telegram', 'chat1');
+      // Grey card for empty state
+      expect(msg.html).toContain('No stats available');
+    });
+
+    it('shows query count and cost when tracker exists', () => {
+      (sdkEngine.getCostTracker as any).mockReturnValue({
+        queryCount: 5,
+        sessionTotalUsd: 1.47,
+      });
+      const msg = panel.buildStatsCard('telegram', 'chat1');
+      expect(msg.html).toContain('5');
+      expect(msg.html).toContain('$1.47');
+    });
+
+    it('discord stats use embed fields', () => {
+      (sdkEngine.getCostTracker as any).mockReturnValue({
+        queryCount: 3,
+        sessionTotalUsd: 0.52,
+      });
+      const msg = panel.buildStatsCard('discord', 'chat1');
+      expect(msg.embed?.title).toBe('📊 Session Stats');
+      expect(msg.embed?.fields).toHaveLength(2);
+    });
+  });
+
+  describe('session interactions', () => {
+    it('session switch rebinds and returns to main panel', async () => {
+      const adapter = mockAdapter();
+      await panel.handleCallback(adapter, 'chat1', 'msg1', 'session:switch:sess-123:telegram:chat1');
+      expect(router.rebind).toHaveBeenCalledWith('telegram', 'chat1', 'sess-123');
+      expect(state.clearLastActive).toHaveBeenCalledWith('telegram', 'chat1');
+      const edited = (adapter.editMessage as any).mock.calls[0][2] as OutboundMessage;
+      expect(edited.html).toContain('⚙️ TLive');
+    });
+
+    it('session new creates new session and returns to main panel', async () => {
+      const adapter = mockAdapter();
+      await panel.handleCallback(adapter, 'chat1', 'msg1', 'session:new:telegram:chat1');
+      expect(onNewSession).toHaveBeenCalledWith('telegram', 'chat1');
+      expect(router.rebind).toHaveBeenCalled();
+      expect(state.clearLastActive).toHaveBeenCalledWith('telegram', 'chat1');
+      expect(state.clearThread).toHaveBeenCalledWith('telegram', 'chat1');
+    });
+  });
+
+  describe('callback data format', () => {
+    it('includes chatKey in all main panel buttons', () => {
+      const msg = panel.buildMainPanel('telegram', 'chat1');
+      for (const btn of msg.buttons!) {
+        expect(btn.callbackData).toContain('telegram:chat1');
+        expect(btn.callbackData).toMatch(/^panel:/);
+      }
+    });
+  });
+});

--- a/bridge/src/channels/telegram.ts
+++ b/bridge/src/channels/telegram.ts
@@ -75,10 +75,10 @@ export class TelegramAdapter extends BaseChannelAdapter {
       }
       // Register native commands to BotFather menu
       await this.bot.api.setMyCommands([
+        { command: 'menu', description: '⚙️ Control Panel' },
         { command: 'new', description: 'New conversation' },
         { command: 'sessions', description: 'List recent sessions' },
         { command: 'session', description: 'Switch to session #n' },
-        { command: 'verbose', description: 'Set detail level (0/1)' },
         { command: 'model', description: 'Switch model' },
         { command: 'runtime', description: 'Switch provider (claude/codex)' },
         { command: 'settings', description: 'Settings scope (user/full/isolated)' },

--- a/bridge/src/engine/bridge-manager.ts
+++ b/bridge/src/engine/bridge-manager.ts
@@ -14,11 +14,12 @@ import { CallbackRouter } from './callback-router.js';
 import { SDKEngine } from './sdk-engine.js';
 import { HookEngine } from './hook-engine.js';
 import { MessageRouter } from './message-router.js';
+import { ControlPanel } from './control-panel.js';
 export type { HookNotificationData } from './hook-engine.js';
 import { networkInterfaces } from 'node:os';
 
 /** Bridge commands handled synchronously (don't block adapter loop) */
-const QUICK_COMMANDS = new Set(['/new', '/status', '/verbose', '/hooks', '/sessions', '/session', '/help', '/perm', '/effort', '/stop', '/approve', '/pairings', '/runtime', '/settings', '/model']);
+const QUICK_COMMANDS = new Set(['/menu', '/new', '/status', '/verbose', '/hooks', '/sessions', '/session', '/help', '/perm', '/effort', '/stop', '/approve', '/pairings', '/runtime', '/settings', '/model']);
 
 function isPrivateIPv4(ip: string): boolean {
   const parts = ip.split('.').map(Number);
@@ -92,6 +93,17 @@ export class BridgeManager {
       () => this.coreAvailable,
       (adapter, msg) => this.handleInboundMessage(adapter, msg),
     );
+
+    // Wire control panel into command & callback routers
+    const controlPanel = new ControlPanel(
+      this.state,
+      this.sdkEngine,
+      this.sdkEngine.getActiveControls(),
+      this.router,
+      (channelType, chatId) => this.sdkEngine.closeSession(channelType, chatId),
+    );
+    this.commands.setControlPanel(controlPanel);
+    this.callbackRouter.setControlPanel(controlPanel);
   }
 
   /** Expose coreAvailable flag for main.ts polling loop */

--- a/bridge/src/engine/callback-router.ts
+++ b/bridge/src/engine/callback-router.ts
@@ -1,6 +1,7 @@
 import type { BaseChannelAdapter } from '../channels/base.js';
 import type { InboundMessage } from '../channels/types.js';
 import type { PermissionCoordinator } from './permission-coordinator.js';
+import type { ControlPanel } from './control-panel.js';
 
 /** Shared SDK question state — owned by SDKEngine, read/written by CallbackRouter */
 export interface SdkQuestionState {
@@ -13,9 +14,12 @@ export interface SdkQuestionState {
  * Routes all button callback interactions from IM platforms.
  *
  * Handles: prompt suggestions, AskUserQuestion buttons (single/multi-select),
- * hook permission callbacks, SDK permission callbacks, and broker callbacks.
+ * hook permission callbacks, SDK permission callbacks, broker callbacks,
+ * and control panel interactions.
  */
 export class CallbackRouter {
+  private controlPanel?: ControlPanel;
+
   constructor(
     private permissions: PermissionCoordinator,
     private sdkState: SdkQuestionState,
@@ -23,8 +27,20 @@ export class CallbackRouter {
     private handleInboundMessage: (adapter: BaseChannelAdapter, msg: InboundMessage) => Promise<boolean>,
   ) {}
 
+  /** Inject ControlPanel after construction (avoids circular deps) */
+  setControlPanel(panel: ControlPanel): void {
+    this.controlPanel = panel;
+  }
+
   async handle(adapter: BaseChannelAdapter, msg: InboundMessage): Promise<boolean> {
     if (!msg.callbackData) return false;
+
+    // Control panel callbacks (panel:{action}:{chatKey})
+    if (msg.callbackData.startsWith('panel:') && this.controlPanel) {
+      const action = msg.callbackData.slice('panel:'.length);
+      await this.controlPanel.handleCallback(adapter, msg.chatId, msg.messageId, action);
+      return true;
+    }
 
     // Prompt suggestion callback — re-inject as a normal user message
     if (msg.callbackData.startsWith('suggest:')) {

--- a/bridge/src/engine/command-router.ts
+++ b/bridge/src/engine/command-router.ts
@@ -4,6 +4,7 @@ import type { SessionStateManager } from './session-state.js';
 import type { ChannelRouter } from './router.js';
 import type { QueryControls } from '../providers/base.js';
 import type { VerboseLevel } from './session-state.js';
+import type { ControlPanel } from './control-panel.js';
 import { getBridgeContext } from '../context.js';
 import { ClaudeSDKProvider } from '../providers/claude-sdk.js';
 import { checkCodexAvailable } from '../providers/index.js';
@@ -13,6 +14,8 @@ import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 
 export class CommandRouter {
+  private controlPanel?: ControlPanel;
+
   constructor(
     private state: SessionStateManager,
     private getAdapters: () => Map<string, BaseChannelAdapter>,
@@ -23,11 +26,26 @@ export class CommandRouter {
     private onNewSession?: (channelType: string, chatId: string) => void,
   ) {}
 
+  private static MENU_HINT = '\n\n💡 Tip: Use /menu for the new control panel';
+
+  /** Inject ControlPanel after construction (avoids circular deps) */
+  setControlPanel(panel: ControlPanel): void {
+    this.controlPanel = panel;
+  }
+
   async handle(adapter: BaseChannelAdapter, msg: InboundMessage): Promise<boolean> {
     const parts = msg.text.split(' ');
     const cmd = parts[0].toLowerCase();
 
     switch (cmd) {
+      case '/menu': {
+        if (this.controlPanel) {
+          await this.controlPanel.show(adapter, msg.chatId);
+        } else {
+          await adapter.send({ chatId: msg.chatId, text: '⚠️ Control panel not available' });
+        }
+        return true;
+      }
       case '/status': {
         const ctx = getBridgeContext();
         const healthy = (ctx.core as { isHealthy?: () => boolean }).isHealthy?.() ?? false;
@@ -95,7 +113,7 @@ export class CommandRouter {
         if ([0, 1].includes(level)) {
           this.state.setVerboseLevel(msg.channelType, msg.chatId, level);
           const labels = ['🤫 quiet', '📝 terminal card'];
-          const text = `Verbose: ${labels[level]}`;
+          const text = `Verbose: ${labels[level]}${CommandRouter.MENU_HINT}`;
           if (adapter.channelType === 'discord') {
             await adapter.send({ chatId: msg.chatId, embed: { description: text, color: 0x3399FF } });
           } else {
@@ -115,9 +133,9 @@ export class CommandRouter {
         const sub = parts[1]?.toLowerCase();
         if (sub === 'on' || sub === 'off') {
           this.state.setPermMode(msg.channelType, msg.chatId, sub);
-          const text = sub === 'on'
+          const text = (sub === 'on'
             ? '🔐 Permission prompts: ON — dangerous tools will ask for confirmation'
-            : '⚡ Permission prompts: OFF — all tools auto-allowed';
+            : '⚡ Permission prompts: OFF — all tools auto-allowed') + CommandRouter.MENU_HINT;
           if (adapter.channelType === 'discord') {
             await adapter.send({ chatId: msg.chatId, embed: { description: text, color: sub === 'on' ? 0xFFA500 : 0x00CC00 } });
           } else {
@@ -140,7 +158,7 @@ export class CommandRouter {
         if (ctrl) {
           this.activeControls.delete(chatKey);
           await ctrl.interrupt();
-          await adapter.send({ chatId: msg.chatId, text: '⏹ Interrupted current execution' });
+          await adapter.send({ chatId: msg.chatId, text: '⏹ Interrupted current execution' + CommandRouter.MENU_HINT });
         } else {
           await adapter.send({ chatId: msg.chatId, text: '⚠️ No active execution to stop' });
         }
@@ -152,7 +170,7 @@ export class CommandRouter {
         if (level && LEVELS.includes(level as typeof LEVELS[number])) {
           this.state.setEffort(msg.channelType, msg.chatId, level as typeof LEVELS[number]);
           const icons: Record<string, string> = { low: '⚡', medium: '🧠', high: '💪', max: '🔥' };
-          const text = `${icons[level] || '🧠'} Effort: **${level}**`;
+          const text = `${icons[level] || '🧠'} Effort: **${level}**${CommandRouter.MENU_HINT}`;
           await adapter.send({ chatId: msg.chatId, text });
         } else {
           const current = this.state.getEffort(msg.channelType, msg.chatId) || 'default';
@@ -298,10 +316,10 @@ export class CommandRouter {
         if (model) {
           if (model === 'reset' || model === 'default') {
             this.state.setModel(msg.channelType, msg.chatId, undefined);
-            await adapter.send({ chatId: msg.chatId, text: '🤖 Model: reset to default' });
+            await adapter.send({ chatId: msg.chatId, text: '🤖 Model: reset to default' + CommandRouter.MENU_HINT });
           } else {
             this.state.setModel(msg.channelType, msg.chatId, model);
-            await adapter.send({ chatId: msg.chatId, text: `🤖 Model: **${model}**` });
+            await adapter.send({ chatId: msg.chatId, text: `🤖 Model: **${model}**${CommandRouter.MENU_HINT}` });
           }
         } else {
           const current = this.state.getModel(msg.channelType, msg.chatId) || 'default';
@@ -367,21 +385,18 @@ export class CommandRouter {
           const html = [
             '<b>❓ TLive Commands</b>',
             '',
+            '<code>/menu</code> — ⚙️ <b>Control Panel</b> ✨',
             '<code>/new</code> — New conversation',
-            '<code>/sessions</code> — List recent sessions',
-            '<code>/session &lt;n&gt;</code> — Switch to session #n',
-            '<code>/verbose 0|1</code> — Detail level',
-            '  0 = quiet · 1 = terminal card',
-            '<code>/perm on|off</code> — Tool permission prompts',
-            '<code>/effort low|high|max</code> — Thinking depth',
-            '<code>/model &lt;name&gt;</code> — Switch model',
+            '',
+            '<i>Legacy (use /menu instead):</i>',
+            '<code>/sessions</code> · <code>/perm</code> · <code>/effort</code>',
+            '<code>/model</code> · <code>/stop</code> · <code>/verbose</code>',
+            '',
             '<code>/runtime claude|codex</code> — Switch AI provider',
             '<code>/settings user|full|isolated</code> — Claude settings scope',
-            '<code>/stop</code> — Interrupt current execution',
             '<code>/hooks pause|resume</code> — Toggle IM approval',
             '<code>/status</code> — Bridge status',
             '<code>/approve &lt;code&gt;</code> — Approve pairing request',
-            '<code>/pairings</code> — List pending pairings',
             '<code>/help</code> — This message',
             '',
             '<i>💬 Reply <b>allow</b>/<b>deny</b> to approve permissions</i>',
@@ -394,19 +409,17 @@ export class CommandRouter {
               title: '❓ TLive Commands',
               color: 0x5865F2,
               description: [
+                '`/menu` — **⚙️ Control Panel** ✨',
                 '`/new` — New conversation',
-                '`/sessions` — List recent sessions',
-                '`/session <n>` — Switch to session #n',
-                '`/verbose 0|1` — Detail level',
-                '> 0 = quiet · 1 = terminal card',
-                '`/perm on|off` — Tool permission prompts',
-                '`/model <name>` — Switch model',
+                '',
+                '*Legacy (use /menu instead):*',
+                '`/sessions` · `/perm` · `/effort` · `/model` · `/stop` · `/verbose`',
+                '',
                 '`/runtime claude|codex` — Switch AI provider',
                 '`/settings user|full|isolated` — Claude settings scope',
                 '`/hooks pause|resume` — Toggle IM approval',
                 '`/status` — Bridge status',
                 '`/approve <code>` — Approve pairing request',
-                '`/pairings` — List pending pairings',
                 '`/help` — This message',
                 '',
                 '*💬 Reply `allow`/`deny` to approve permissions*',
@@ -415,21 +428,17 @@ export class CommandRouter {
           });
         } else {
           const feishuLines = [
+            '/menu — ⚙️ **Control Panel** ✨',
             '/new — New conversation',
-            '/sessions — List recent sessions',
-            '/session <n> — Switch to session #n',
-            '/verbose 0|1 — Detail level',
-            '  0 = quiet · 1 = terminal card',
-            '/perm on|off — Tool permission prompts',
-            '/effort low|high|max — Thinking depth',
-            '/model <name> — Switch model',
+            '',
+            '*Legacy (use /menu instead):*',
+            '/sessions · /perm · /effort · /model · /stop · /verbose',
+            '',
             '/runtime claude|codex — Switch AI provider',
             '/settings user|full|isolated — Claude settings scope',
-            '/stop — Interrupt current execution',
             '/hooks pause|resume — Toggle IM approval',
             '/status — Bridge status',
             '/approve <code> — Approve pairing request',
-            '/pairings — List pending pairings',
             '/help — This message',
             '',
             '💬 回复 **allow** / **deny** 审批权限',

--- a/bridge/src/engine/control-panel.ts
+++ b/bridge/src/engine/control-panel.ts
@@ -1,0 +1,431 @@
+import type { BaseChannelAdapter } from '../channels/base.js';
+import type { SessionStateManager } from './session-state.js';
+import type { SDKEngine } from './sdk-engine.js';
+import type { ChannelRouter } from './router.js';
+import type { OutboundMessage, Button } from '../channels/types.js';
+import type { QueryControls } from '../providers/base.js';
+import { getBridgeContext } from '../context.js';
+
+/**
+ * Button-based control panel for managing TLive sessions.
+ * Renders a single card that is edited in-place for sub-menus.
+ */
+export class ControlPanel {
+  constructor(
+    private state: SessionStateManager,
+    private sdkEngine: SDKEngine,
+    private activeControls: Map<string, QueryControls>,
+    private router: ChannelRouter,
+    private onNewSession?: (channelType: string, chatId: string) => void,
+  ) {}
+
+  /** Render the main panel card */
+  async show(adapter: BaseChannelAdapter, chatId: string): Promise<void> {
+    const msg = this.buildMainPanel(adapter.channelType, chatId);
+    await adapter.send(msg);
+  }
+
+  /** Handle a panel callback — called by CallbackRouter */
+  async handleCallback(
+    adapter: BaseChannelAdapter,
+    chatId: string,
+    messageId: string,
+    action: string,
+  ): Promise<void> {
+    // Strip chatKey suffix from action
+    const parts = action.split(':');
+    const command = parts[0];
+
+    switch (command) {
+      case 'model':
+        if (parts[1] === 'select') {
+          // panel:model:select:{modelName}:{chatKey}
+          const modelName = parts[2];
+          if (modelName === 'default') {
+            this.state.setModel(adapter.channelType, chatId, undefined);
+          } else {
+            this.state.setModel(adapter.channelType, chatId, modelName);
+          }
+          await adapter.editMessage(chatId, messageId, this.buildMainPanel(adapter.channelType, chatId));
+        } else {
+          await adapter.editMessage(chatId, messageId, this.buildModelPicker(adapter.channelType, chatId));
+        }
+        break;
+
+      case 'effort':
+        if (parts[1] === 'select') {
+          const level = parts[2] as 'low' | 'medium' | 'high' | 'max';
+          this.state.setEffort(adapter.channelType, chatId, level);
+          await adapter.editMessage(chatId, messageId, this.buildMainPanel(adapter.channelType, chatId));
+        } else {
+          await adapter.editMessage(chatId, messageId, this.buildEffortPicker(adapter.channelType, chatId));
+        }
+        break;
+
+      case 'perm': {
+        const current = this.state.getPermMode(adapter.channelType, chatId);
+        this.state.setPermMode(adapter.channelType, chatId, current === 'on' ? 'off' : 'on');
+        await adapter.editMessage(chatId, messageId, this.buildMainPanel(adapter.channelType, chatId));
+        break;
+      }
+
+      case 'sessions':
+        await adapter.editMessage(chatId, messageId, await this.buildSessionList(adapter.channelType, chatId));
+        break;
+
+      case 'stop': {
+        const chatKey = this.state.stateKey(adapter.channelType, chatId);
+        const ctrl = this.activeControls.get(chatKey);
+        if (ctrl) {
+          this.activeControls.delete(chatKey);
+          await ctrl.interrupt();
+        }
+        await adapter.editMessage(chatId, messageId, this.buildMainPanel(adapter.channelType, chatId));
+        break;
+      }
+
+      case 'stats':
+        await adapter.editMessage(chatId, messageId, this.buildStatsCard(adapter.channelType, chatId));
+        break;
+
+      case 'session':
+        if (parts[1] === 'switch') {
+          // panel:session:switch:{sessionId}:{chatKey}
+          const targetSessionId = parts[2];
+          await this.router.rebind(adapter.channelType, chatId, targetSessionId);
+          this.state.clearLastActive(adapter.channelType, chatId);
+          await adapter.editMessage(chatId, messageId, this.buildMainPanel(adapter.channelType, chatId));
+        } else if (parts[1] === 'new') {
+          this.onNewSession?.(adapter.channelType, chatId);
+          const newSessionId = `session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+          await this.router.rebind(adapter.channelType, chatId, newSessionId);
+          this.state.clearLastActive(adapter.channelType, chatId);
+          this.state.clearThread(adapter.channelType, chatId);
+          await adapter.editMessage(chatId, messageId, this.buildMainPanel(adapter.channelType, chatId));
+        }
+        break;
+
+      case 'back':
+        await adapter.editMessage(chatId, messageId, this.buildMainPanel(adapter.channelType, chatId));
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  // ── Card Builders ──────────────────────────────────────────────
+
+  buildMainPanel(channelType: string, chatId: string): OutboundMessage {
+    const model = this.state.getModel(channelType, chatId) || 'default';
+    const effort = this.state.getEffort(channelType, chatId) || 'default';
+    const perm = this.state.getPermMode(channelType, chatId);
+    const runtime = this.state.getRuntime(channelType, chatId) || 'claude';
+    const chatKey = `${channelType}:${chatId}`;
+
+    const effortIcons: Record<string, string> = { low: '⚡', medium: '🧠', high: '💪', max: '🔥', default: '⚡' };
+    const permIcon = perm === 'on' ? '🔒' : '🔓';
+    const runtimeIcon = runtime === 'codex' ? '🟢' : '🟣';
+
+    const buttons: Button[] = [
+      { label: '🤖 Model', callbackData: `panel:model:${chatKey}`, style: 'default', row: 0 },
+      { label: `${effortIcons[effort] || '⚡'} Effort`, callbackData: `panel:effort:${chatKey}`, style: 'default', row: 0 },
+      { label: `${permIcon} Perm`, callbackData: `panel:perm:${chatKey}`, style: 'default', row: 0 },
+      { label: '📋 Sessions', callbackData: `panel:sessions:${chatKey}`, style: 'default', row: 1 },
+      { label: '⏹ Stop', callbackData: `panel:stop:${chatKey}`, style: 'danger', row: 1 },
+      { label: '📊 Stats', callbackData: `panel:stats:${chatKey}`, style: 'default', row: 1 },
+    ];
+
+    if (channelType === 'telegram') {
+      const html = [
+        `<b>⚙️ TLive</b>`,
+        ``,
+        `${runtimeIcon} <code>${runtime}</code>  ·  🤖 <code>${model}</code>`,
+        `${effortIcons[effort] || '⚡'} <code>${effort}</code>  ·  ${permIcon} Perm: <code>${perm.toUpperCase()}</code>`,
+      ].join('\n');
+      return { chatId, html, buttons };
+    }
+
+    if (channelType === 'discord') {
+      return {
+        chatId,
+        embed: {
+          title: '⚙️ TLive',
+          color: 0x3399FF,
+          fields: [
+            { name: `${runtimeIcon} Runtime`, value: `\`${runtime}\``, inline: true },
+            { name: '🤖 Model', value: `\`${model}\``, inline: true },
+            { name: `${effortIcons[effort] || '⚡'} Effort`, value: `\`${effort}\``, inline: true },
+            { name: `${permIcon} Perm`, value: `\`${perm.toUpperCase()}\``, inline: true },
+          ],
+        },
+        buttons,
+      };
+    }
+
+    // Feishu
+    const body = [
+      `${runtimeIcon} ${runtime}  ·  🤖 ${model}`,
+      `${effortIcons[effort] || '⚡'} ${effort}  ·  ${permIcon} Perm: ${perm.toUpperCase()}`,
+    ].join('\n');
+    return {
+      chatId,
+      text: body,
+      feishuHeader: { template: 'blue', title: '⚙️ TLive' },
+      buttons,
+    };
+  }
+
+  buildModelPicker(channelType: string, chatId: string): OutboundMessage {
+    const current = this.state.getModel(channelType, chatId) || 'default';
+    const runtime = this.state.getRuntime(channelType, chatId) || 'claude';
+    const chatKey = `${channelType}:${chatId}`;
+
+    const models = runtime === 'codex'
+      ? ['codex-mini', 'o4-mini', 'o3']
+      : ['claude-sonnet-4-6', 'claude-opus-4-6', 'claude-haiku-4-5'];
+
+    const buttons: Button[] = models.map((m, i) => ({
+      label: m === current ? `✓ ${m}` : m,
+      callbackData: `panel:model:select:${m}:${chatKey}`,
+      style: m === current ? 'primary' as const : 'default' as const,
+      row: i,
+    }));
+
+    // Default/reset button on same row as last model
+    buttons.push({
+      label: current === 'default' ? '✓ default' : 'default',
+      callbackData: `panel:model:select:default:${chatKey}`,
+      style: current === 'default' ? 'primary' : 'default',
+      row: models.length,
+    });
+
+    // Back button
+    buttons.push({
+      label: '↩ Back',
+      callbackData: `panel:back:${chatKey}`,
+      style: 'default',
+      row: models.length + 1,
+    });
+
+    return this.renderCard(channelType, chatId, {
+      title: '🤖 Select Model',
+      body: `Current: ${current}`,
+      buttons,
+      color: 0x9B59B6,
+      feishuTemplate: 'indigo',
+    });
+  }
+
+  buildEffortPicker(channelType: string, chatId: string): OutboundMessage {
+    const current = this.state.getEffort(channelType, chatId) || 'default';
+    const chatKey = `${channelType}:${chatId}`;
+
+    const levels = [
+      { key: 'low', label: '⚡ Low', row: 0 },
+      { key: 'medium', label: '🧠 Medium', row: 0 },
+      { key: 'high', label: '💪 High', row: 1 },
+      { key: 'max', label: '🔥 Max', row: 1 },
+    ];
+
+    const buttons: Button[] = levels.map(l => ({
+      label: l.key === current ? `${l.label} ✓` : l.label,
+      callbackData: `panel:effort:select:${l.key}:${chatKey}`,
+      style: l.key === current ? 'primary' as const : 'default' as const,
+      row: l.row,  // 2x2 grid
+    }));
+
+    buttons.push({
+      label: '↩ Back',
+      callbackData: `panel:back:${chatKey}`,
+      style: 'default',
+      row: 2,
+    });
+
+    return this.renderCard(channelType, chatId, {
+      title: '⚡ Select Effort',
+      body: `Current: ${current}`,
+      buttons,
+      color: 0xF39C12,
+      feishuTemplate: 'orange',
+    });
+  }
+
+  async buildSessionList(channelType: string, chatId: string): Promise<OutboundMessage> {
+    const chatKey = `${channelType}:${chatId}`;
+
+    try {
+      const { store } = getBridgeContext();
+      const allSessions = await store.listSessions();
+      const binding = await this.router.resolve(channelType, chatId);
+      const currentSessionId = binding?.sessionId;
+
+      const sorted = allSessions
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+        .slice(0, 5);
+
+      if (sorted.length === 0) {
+        return this.renderCard(channelType, chatId, {
+          title: '📋 Sessions',
+          body: 'No sessions found.',
+          buttons: [
+            { label: '➕ New', callbackData: `panel:session:new:${chatKey}`, style: 'primary', row: 0 },
+            { label: '↩ Back', callbackData: `panel:back:${chatKey}`, style: 'default', row: 0 },
+          ],
+          color: 0x3399FF,
+          feishuTemplate: 'blue',
+        });
+      }
+
+      const lines: string[] = [];
+      const buttons: Button[] = [];
+      for (let i = 0; i < sorted.length; i++) {
+        const s = sorted[i];
+        const isCurrent = s.id === currentSessionId;
+        const msgs = await store.getMessages(s.id);
+        const firstUser = msgs.find(m => m.role === 'user');
+        const preview = firstUser
+          ? (firstUser.content.length > 25 ? firstUser.content.slice(0, 22) + '...' : firstUser.content)
+          : '(empty)';
+        const ago = this.timeAgo(new Date(s.createdAt));
+        const marker = isCurrent ? ' ◀' : '';
+        lines.push(`${isCurrent ? '●' : '○'} ${preview} · ${ago}${marker}`);
+
+        if (!isCurrent) {
+          buttons.push({
+            label: `${i + 1}. Switch`,
+            callbackData: `panel:session:switch:${s.id}:${chatKey}`,
+            style: 'default',
+            row: Math.floor(i / 3),
+          });
+        }
+      }
+
+      // Bottom row: New + Back
+      const lastRow = (buttons.length > 0 ? Math.floor((buttons.length - 1) / 3) : 0) + 1;
+      buttons.push(
+        { label: '➕ New', callbackData: `panel:session:new:${chatKey}`, style: 'primary', row: lastRow },
+        { label: '↩ Back', callbackData: `panel:back:${chatKey}`, style: 'default', row: lastRow },
+      );
+
+      return this.renderCard(channelType, chatId, {
+        title: '📋 Sessions',
+        body: lines.join('\n'),
+        buttons,
+        color: 0x3399FF,
+        feishuTemplate: 'blue',
+      });
+    } catch {
+      return this.renderCard(channelType, chatId, {
+        title: '📋 Sessions',
+        body: 'Unable to load sessions.',
+        buttons: [{ label: '↩ Back', callbackData: `panel:back:${chatKey}`, style: 'default', row: 0 }],
+        color: 0xE74C3C,
+        feishuTemplate: 'red',
+      });
+    }
+  }
+
+  buildStatsCard(channelType: string, chatId: string): OutboundMessage {
+    const chatKey = `${channelType}:${chatId}`;
+    const tracker = this.sdkEngine.getCostTracker(channelType, chatId);
+    const backBtn: Button = { label: '↩ Back', callbackData: `panel:back:${chatKey}`, style: 'default', row: 0 };
+
+    if (!tracker || tracker.queryCount === 0) {
+      return this.renderCard(channelType, chatId, {
+        title: '📊 Session Stats',
+        body: 'No stats available yet.\nSend a message to start tracking.',
+        buttons: [backBtn],
+        color: 0x95A5A6,
+        feishuTemplate: 'grey',
+      });
+    }
+
+    const queries = tracker.queryCount;
+    const cost = `$${tracker.sessionTotalUsd.toFixed(2)}`;
+
+    if (channelType === 'discord') {
+      return {
+        chatId,
+        embed: {
+          title: '📊 Session Stats',
+          color: 0x2ECC71,
+          fields: [
+            { name: '💬 Queries', value: `\`${queries}\``, inline: true },
+            { name: '💰 Cost', value: `\`${cost}\``, inline: true },
+          ],
+        },
+        buttons: [backBtn],
+      };
+    }
+
+    if (channelType === 'telegram') {
+      const html = [
+        `<b>📊 Session Stats</b>`,
+        ``,
+        `💬 Queries: <code>${queries}</code>`,
+        `💰 Cost: <code>${cost}</code>`,
+      ].join('\n');
+      return { chatId, html, buttons: [backBtn] };
+    }
+
+    // Feishu
+    return {
+      chatId,
+      text: `💬 Queries: ${queries}\n💰 Cost: ${cost}`,
+      feishuHeader: { template: 'green', title: '📊 Session Stats' },
+      buttons: [backBtn],
+    };
+  }
+
+  // ── Rendering helpers ──────────────────────────────────────────
+
+  private renderCard(
+    channelType: string,
+    chatId: string,
+    opts: { title: string; body: string; buttons: Button[]; color: number; feishuTemplate: string },
+  ): OutboundMessage {
+    if (channelType === 'telegram') {
+      return {
+        chatId,
+        html: `<b>${opts.title}</b>\n\n${this.escapeHtml(opts.body)}`,
+        buttons: opts.buttons,
+      };
+    }
+
+    if (channelType === 'discord') {
+      return {
+        chatId,
+        embed: {
+          title: opts.title,
+          description: opts.body,
+          color: opts.color,
+        },
+        buttons: opts.buttons,
+      };
+    }
+
+    // Feishu
+    return {
+      chatId,
+      text: opts.body,
+      feishuHeader: { template: opts.feishuTemplate, title: opts.title },
+      buttons: opts.buttons,
+    };
+  }
+
+  private escapeHtml(text: string): string {
+    return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  private timeAgo(date: Date): string {
+    const diff = Date.now() - date.getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+  }
+}

--- a/bridge/src/engine/cost-tracker.ts
+++ b/bridge/src/engine/cost-tracker.ts
@@ -66,6 +66,7 @@ export class CostTracker {
   }
 
   get queryCount(): number { return this._queryCount; }
+  get sessionTotalUsd(): number { return this.sessionTotal; }
 
   static format(stats: UsageStats): string {
     const duration = formatDuration(stats.durationMs);

--- a/bridge/src/engine/sdk-engine.ts
+++ b/bridge/src/engine/sdk-engine.ts
@@ -204,6 +204,18 @@ export class SDKEngine {
     return this.activeControls;
   }
 
+  /** Expose cost tracker for a given chat (used by ControlPanel stats) */
+  getCostTracker(channelType: string, chatId: string): CostTracker | null {
+    const stateKey = `${channelType}:${chatId}`;
+    // Find first registry entry matching this chat
+    for (const [key, managed] of this.registry) {
+      if (key.startsWith(stateKey + ':') || key === stateKey) {
+        return managed.costTracker;
+      }
+    }
+    return null;
+  }
+
   /** Find pending SDK question for text reply routing */
   findPendingQuestion(_channelType: string, chatId: string): { permId: string } | null {
     for (const [permId, data] of this.sdkQuestionData) {


### PR DESCRIPTION
## Summary

- **New `/menu` command** opens a visual control panel card with 6 action buttons (Model, Effort, Perm, Sessions, Stop, Stats)
- **Sub-menus** edit the same card in-place: model picker, effort picker (2×2 grid), session list with Switch/New buttons, stats card
- **Per-platform rendering**: Telegram HTML + InlineKeyboard, Discord Embed + Buttons, Feishu Interactive Card
- **Deprecation path**: old text commands (`/perm`, `/effort`, `/model`, `/stop`, `/verbose`) now show "💡 Tip: Use /menu" hint; `/help` reorganized to feature `/menu`
- **Telegram bot commands** updated to include `/menu` at top of list
- Minor additions: `CostTracker.sessionTotalUsd` getter, `SDKEngine.getCostTracker()` for stats

## Test plan
- [x] 26 unit tests passing (control-panel.test.ts)
- [x] Full suite: 474/476 passing (2 pre-existing markdown-it failures)
- [x] Manual test: Telegram `/menu` → verify card + all sub-menus
- [x] Manual test: Discord `/menu` → verify embed + buttons
- [x] Manual test: Feishu `/menu` → verify card header + buttons