### PR TITLE
docs: add TL_CLAUDE_SETTINGS configuration guide

### DIFF
--- a/docs/getting-started-cn.md
+++ b/docs/getting-started-cn.md
@@ -86,6 +86,24 @@ TL_TOKEN=your-secret-token
 chmod 600 ~/.tlive/config.env
 ```
 
+### Claude Code 配置加载
+
+`TL_CLAUDE_SETTINGS` 控制加载哪些 Claude Code 配置文件，默认值为 `user`。
+
+| 值 | 加载内容 | 用途 |
+|----|---------|------|
+| `user` | `~/.claude/settings.json` | 认证、模型、环境变量（如 `ANTHROPIC_AUTH_TOKEN`、`ANTHROPIC_BASE_URL`） |
+| `project` | `.claude/settings.json` + `CLAUDE.md` | 项目规则、MCP、skills |
+| `local` | `.claude/settings.local.json` | 开发者覆盖 |
+
+```env
+TL_CLAUDE_SETTINGS=user            # 默认 — 只加载用户配置
+TL_CLAUDE_SETTINGS=user,project    # 用户 + 项目配置
+TL_CLAUDE_SETTINGS=                # 完全隔离
+```
+
+> **提示：** 如果你使用 **ccswitch** 等工具在 `~/.claude/settings.json` 中配置了 `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL`，默认的 `user` 设置已经会读取，无需额外配置。
+
 ## 安装 Claude Code 集成
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,6 +86,24 @@ Make sure to secure the config file:
 chmod 600 ~/.tlive/config.env
 ```
 
+### Claude Code Settings Sources
+
+`TL_CLAUDE_SETTINGS` controls which Claude Code settings files to load. Default: `user`.
+
+| Value | Loads | Use case |
+|-------|-------|----------|
+| `user` | `~/.claude/settings.json` | Auth, model, env (e.g. `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`) |
+| `project` | `.claude/settings.json` + `CLAUDE.md` | Project rules, MCP, skills |
+| `local` | `.claude/settings.local.json` | Developer overrides |
+
+```env
+TL_CLAUDE_SETTINGS=user            # Default — user config only
+TL_CLAUDE_SETTINGS=user,project    # User + project config
+TL_CLAUDE_SETTINGS=                # Full isolation
+```
+
+> **Tip:** If you use tools like **ccswitch** that set `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL` in `~/.claude/settings.json`, the default `user` setting already covers this.
+
 ## Install Claude Code Integration
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `TL_CLAUDE_SETTINGS` documentation to getting-started guides (EN/CN)
- Explains `user` / `project` / `local` settings sources with examples
- Clarifies that ccswitch users' `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL` in `~/.claude/settings.json` are already covered by the default `user` setting

## Test plan
- [x] Verify markdown renders correctly on GitHub