### PR TITLE
Harden IM delivery and improve Telegram diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,49 @@ To access the web terminal from outside your LAN (e.g. via frpc, Cloudflare Tunn
 - IM user whitelists are configured (`TL_TG_ALLOWED_USERS`, `TL_DC_ALLOWED_USERS`, etc.)
 - Use HTTPS on the tunnel side (frps/Cloudflare handle this automatically)
 
+## Troubleshooting: wrong working directory in IM Bridge
+
+If the IM Bridge replies that it is in `/` or cannot safely read project files, check the bridge logs in this order:
+
+1. Startup `defaultWorkdir`
+   - Confirm the bridge startup log shows:
+     - resolved `defaultWorkdir`
+     - current `process.cwd()`
+     - source: `TL_DEFAULT_WORKDIR` or fallback `process.cwd()`
+   - If `defaultWorkdir` is `/`, non-absolute, missing, or not a directory, fix startup configuration first.
+
+2. Router session bootstrap
+   - For a fresh chat or after `/new`, confirm router logs show:
+     - binding creation or reuse
+     - seeded session row
+     - session `workingDirectory`
+   - This verifies a new IM chat was bound to a session with the expected cwd.
+
+3. SDKEngine effective cwd
+   - Before execution, confirm engine logs show:
+     - stored session cwd
+     - `defaultWorkdir`
+     - final effective cwd
+     - source of the selected cwd
+     - whether healing occurred
+   - This is the authoritative per-turn cwd decision.
+
+Recommended manual repro:
+
+1. Restart the bridge
+2. Run `/new` in Telegram
+3. Send: `請讀取 README.md 第一行，不要修改任何檔案。`
+4. Confirm the reply matches the repository file content
+5. If needed, inspect logs with:
+   ```bash
+   tlive logs 100
+   ```
+
+If the assistant still reports `/`, the logs should show whether the bad cwd came from:
+- startup configuration
+- session persistence
+- execution-time fallback or healing
+
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ Claude Code runs normally in your terminal (no wrapper needed)
 ```
 
 **Safe by design:**
-- Timeout defaults to **deny** (not allow)
+- If Go Core is unreachable, hooks pass through locally (zero impact on normal usage)
+- Once Go Core accepts a PermissionRequest, timeout/error defaults to **deny** (not allow)
 - Shows exact tool name and command before you approve
-- Hook script checks if Go Core is running — if not, passes through (zero impact on normal usage)
 - Works with any Claude Code session, no wrapper needed
 
 **Pause when you're at your desk:**

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ TL_ENABLED_CHANNELS=telegram,discord
 TL_TG_BOT_TOKEN=...
 TL_TG_CHAT_ID=...
 TL_TG_REQUIRE_MENTION=true        # @bot required in groups
+TL_TG_POLL_TIMEOUT=10             # optional: lower if long-poll gets ECONNRESET/socket hang up
 TL_TG_DISABLE_LINK_PREVIEW=true   # cleaner messages
 
 # Discord

--- a/bridge/src/__tests__/config.test.ts
+++ b/bridge/src/__tests__/config.test.ts
@@ -85,9 +85,23 @@ describe('loadConfig', () => {
     expect(config.feishu.allowedUsers).toEqual(['fsu1']);
   });
 
-  it('overrides core URL with TL_CORE_URL', () => {
-    process.env.TL_CORE_URL = 'http://core:9999';
+  it('uses TL_DEFAULT_WORKDIR from env', () => {
+    process.env.TL_DEFAULT_WORKDIR = '/tmp/tlive-project';
     const config = loadConfig();
-    expect(config.coreUrl).toBe('http://core:9999');
+    expect(config.defaultWorkdir).toBe('/tmp/tlive-project');
+    expect(config.defaultWorkdirSource).toBe('env');
+    expect(config.defaultWorkdirDiagnostics.path).toBe('/tmp/tlive-project');
+    expect(config.defaultWorkdirDiagnostics.source).toBe('env');
+    expect(config.defaultWorkdirDiagnostics.envValueProvided).toBe(true);
   });
+
+  it('falls back to process.cwd() when TL_DEFAULT_WORKDIR is not set', () => {
+    const config = loadConfig();
+    expect(config.defaultWorkdir).toBe(process.cwd());
+    expect(config.defaultWorkdirSource).toBe('process.cwd');
+    expect(config.defaultWorkdirDiagnostics.path).toBe(process.cwd());
+    expect(config.defaultWorkdirDiagnostics.processCwd).toBe(process.cwd());
+    expect(config.defaultWorkdirDiagnostics.envValueProvided).toBe(false);
+  });
+
 });

--- a/bridge/src/__tests__/conversation.test.ts
+++ b/bridge/src/__tests__/conversation.test.ts
@@ -1,12 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { ConversationEngine } from '../engine/conversation.js';
 import { initBridgeContext } from '../context.js';
 import type { CanonicalEvent } from '../messages/schema.js';
 
 // Mock store
-function createMockStore() {
+function createMockStore(session: { id: string; workingDirectory: string; createdAt: string } | null = { id: 's1', workingDirectory: '/tmp', createdAt: '' }) {
   return {
-    getSession: vi.fn().mockResolvedValue({ id: 's1', workingDirectory: '/tmp', createdAt: '' }),
+    getSession: vi.fn().mockResolvedValue(session),
     saveMessage: vi.fn().mockResolvedValue(undefined),
     getMessages: vi.fn().mockResolvedValue([]),
     acquireLock: vi.fn().mockResolvedValue(true),
@@ -22,7 +25,7 @@ function createMockStore() {
 // Mock LLM that emits controlled CanonicalEvent objects
 function createMockLLM(events: CanonicalEvent[]) {
   return {
-    streamChat: () => ({
+    streamChat: vi.fn(() => ({
       stream: new ReadableStream<CanonicalEvent>({
         start(controller) {
           for (const event of events) {
@@ -32,24 +35,30 @@ function createMockLLM(events: CanonicalEvent[]) {
         }
       }),
       controls: undefined,
-    })
+    }))
   };
 }
 
 describe('ConversationEngine', () => {
   let engine: ConversationEngine;
   let mockStore: ReturnType<typeof createMockStore>;
+  let mockLLM: ReturnType<typeof createMockLLM>;
+  let tempRoot: string;
+  let defaultWorkdir: string;
 
   beforeEach(() => {
-    mockStore = createMockStore();
-    const mockLLM = createMockLLM([
+    tempRoot = mkdtempSync(join(tmpdir(), 'tlive-conversation-'));
+    defaultWorkdir = join(tempRoot, 'project');
+    mkdirSync(defaultWorkdir, { recursive: true });
+    mockStore = createMockStore({ id: 's1', workingDirectory: defaultWorkdir, createdAt: '' });
+    mockLLM = createMockLLM([
       { kind: 'text_delta', text: 'Hello ' },
       { kind: 'text_delta', text: 'world' },
       { kind: 'query_result', sessionId: 's1', isError: false, usage: { inputTokens: 10, outputTokens: 5 } },
     ]);
 
     initBridgeContext({
-      defaultWorkdir: '/tmp',
+      defaultWorkdir,
       store: mockStore as any,
       llm: mockLLM as any,
       permissions: {} as any,
@@ -57,6 +66,10 @@ describe('ConversationEngine', () => {
     });
 
     engine = new ConversationEngine();
+  });
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
   });
 
   it('processes message and returns full response', async () => {
@@ -100,6 +113,41 @@ describe('ConversationEngine', () => {
       onQueryResult: (r) => { resultData = r; },
     });
     expect(resultData.usage.inputTokens).toBe(10);
+  });
+
+  it('uses the default workdir when the session has not been seeded yet', async () => {
+    mockStore = createMockStore(null);
+    mockLLM = createMockLLM([
+      { kind: 'query_result', sessionId: 'sdk-1', isError: false, usage: { inputTokens: 1, outputTokens: 1 } },
+    ]);
+    initBridgeContext({ defaultWorkdir, store: mockStore as any, llm: mockLLM as any, permissions: {} as any, core: {} as any });
+    engine = new ConversationEngine();
+
+    await engine.processMessage({ sessionId: 's1', text: 'hi' });
+
+    expect(mockLLM.streamChat).toHaveBeenCalledWith(expect.objectContaining({ workingDirectory: defaultWorkdir }));
+    expect(mockStore.saveSession).toHaveBeenCalledWith(expect.objectContaining({
+      id: 's1',
+      workingDirectory: defaultWorkdir,
+      sdkSessionId: 'sdk-1',
+    }));
+  });
+
+  it('heals root working directory to defaultWorkdir before execution', async () => {
+    mockStore = createMockStore({ id: 's1', workingDirectory: '/', createdAt: '' });
+    mockLLM = createMockLLM([
+      { kind: 'query_result', sessionId: 'sdk-1', isError: false, usage: { inputTokens: 1, outputTokens: 1 } },
+    ]);
+    initBridgeContext({ defaultWorkdir, store: mockStore as any, llm: mockLLM as any, permissions: {} as any, core: {} as any });
+    engine = new ConversationEngine();
+
+    await engine.processMessage({ sessionId: 's1', text: 'hi' });
+
+    expect(mockLLM.streamChat).toHaveBeenCalledWith(expect.objectContaining({ workingDirectory: defaultWorkdir }));
+    expect(mockStore.saveSession).toHaveBeenCalledWith(expect.objectContaining({
+      id: 's1',
+      workingDirectory: defaultWorkdir,
+    }));
   });
 
   it('releases lock even on error', async () => {

--- a/bridge/src/__tests__/delivery.test.ts
+++ b/bridge/src/__tests__/delivery.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { DeliveryLayer } from '../delivery/delivery.js';
-import { chunkMarkdown } from '../delivery/delivery.js';
+import { chunkMarkdown, chunkByParagraph, labelMultipartChunks, prependMultipartIntro, prepareMultipartText } from '../delivery/delivery.js';
 import type { BaseChannelAdapter } from '../channels/base.js';
 
 function mockAdapter(): BaseChannelAdapter {
@@ -50,6 +50,31 @@ describe('DeliveryLayer', () => {
 });
 
 describe('fence-aware chunking', () => {
+  it('keeps heading with following paragraph when possible', () => {
+    const text = '# Heading\nBody paragraph that should stay attached.';
+    const chunks = chunkByParagraph(text, 200);
+    expect(chunks).toEqual(['# Heading\nBody paragraph that should stay attached.']);
+  });
+
+  it('labels multipart chunks', () => {
+    expect(labelMultipartChunks(['one', 'two'])).toEqual(['[1/2]\none', '[2/2]\ntwo']);
+  });
+
+  it('prepends intro to first multipart chunk', () => {
+    expect(prependMultipartIntro(['one', 'two'], 'Intro')).toEqual(['Intro\n\none', 'two']);
+  });
+
+  it('prepares multipart text with intro and labels', () => {
+    expect(prepareMultipartText('one\n\n' + 'two'.repeat(100), 50, { intro: 'Intro' })[0]).toContain('Intro');
+    expect(prepareMultipartText('one\n\n' + 'two'.repeat(100), 50, { intro: 'Intro' })[0]).toContain('[1/');
+  });
+
+  it('can prepare multipart text without labels', () => {
+    const chunks = prepareMultipartText('one\n\n' + 'two'.repeat(100), 50, { intro: 'Intro', labelParts: false });
+    expect(chunks[0]).toContain('Intro');
+    expect(chunks[0]).not.toContain('[1/');
+  });
+
   it('preserves code block fences across chunks', () => {
     const text = '# Title\n```js\n' + 'let x = 1;\n'.repeat(100) + '```\nEnd.';
     const chunks = chunkMarkdown(text, 200);

--- a/bridge/src/__tests__/discord.test.ts
+++ b/bridge/src/__tests__/discord.test.ts
@@ -146,14 +146,14 @@ describe('DiscordAdapter', () => {
       expect(call.components).toHaveLength(1);
     });
 
-    it('chunks content exceeding 2000 chars into multiple messages', async () => {
+    it('chunks content exceeding 2000 chars into multiple labeled messages', async () => {
       await adapter.start();
-      const longText = 'a'.repeat(2500);
+      const longText = ('## Heading\nBody line\n\n').repeat(180);
       await adapter.send({ chatId: 'channel1', text: longText });
       expect(mockSend.mock.calls.length).toBeGreaterThan(1);
-      // All chunks combined should equal original content
-      const allContent = mockSend.mock.calls.map((c: any) => c[0].content).join('');
-      expect(allContent).toBe(longText);
+      expect(mockSend.mock.calls[0][0].content).toContain('Long reply — split into readable parts.');
+      expect(mockSend.mock.calls[0][0].content).toContain('[1/');
+      expect(mockSend.mock.calls[mockSend.mock.calls.length - 1][0].content).toContain(`[${mockSend.mock.calls.length}/`);
     });
 
     it('sends multiple messages for long content with newlines', async () => {
@@ -231,6 +231,12 @@ describe('DiscordAdapter', () => {
       expect(mockFetchChannel).toHaveBeenCalledWith('channel1');
       expect(mockFetchMessage).toHaveBeenCalledWith('msg-99');
       expect(mockEdit).toHaveBeenCalledWith(expect.objectContaining({ content: 'Updated!' }));
+    });
+
+    it('normalizes heading spacing in edited content', async () => {
+      await adapter.start();
+      await adapter.editMessage('channel1', 'msg-99', { chatId: 'channel1', text: 'Hello\n## Title\nBody' });
+      expect(mockEdit).toHaveBeenCalledWith(expect.objectContaining({ content: 'Hello\n\n**Title**\n\nBody' }));
     });
   });
 

--- a/bridge/src/__tests__/feishu-streaming.test.ts
+++ b/bridge/src/__tests__/feishu-streaming.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { FeishuStreamingSession } from '../channels/feishu-streaming.js';
+
+describe('FeishuStreamingSession', () => {
+  it('normalizes markdown heading spacing on start and update', async () => {
+    const cardCreate = vi.fn().mockResolvedValue({ data: { card_id: 'card-1' } });
+    const messageCreate = vi.fn().mockResolvedValue({ data: { message_id: 'msg-1' } });
+    const cardContent = vi.fn().mockResolvedValue({});
+    const cardSettings = vi.fn().mockResolvedValue({});
+
+    const session = new FeishuStreamingSession({
+      client: {
+        cardkit: {
+          v1: {
+            card: {
+              create: cardCreate,
+              settings: cardSettings,
+            },
+            cardElement: {
+              content: cardContent,
+            },
+          },
+        },
+        im: {
+          message: {
+            create: messageCreate,
+            reply: vi.fn(),
+          },
+        },
+      },
+      chatId: 'oc_chat123',
+    });
+
+    await session.start('Hello\n## Title\nBody');
+    expect(cardCreate).toHaveBeenCalledOnce();
+    const createdPayload = JSON.parse(cardCreate.mock.calls[0][0].data.data);
+    expect(createdPayload.body.elements[0].content).toBe('Hello\n\n**Title**\n\nBody');
+
+    await session.update('Intro\n## Next\nBody');
+    expect(cardContent).toHaveBeenCalledOnce();
+    expect(cardContent.mock.calls[0][0].data.content).toBe('Intro\n\n**Next**\n\nBody');
+  });
+});

--- a/bridge/src/__tests__/feishu.test.ts
+++ b/bridge/src/__tests__/feishu.test.ts
@@ -128,6 +128,36 @@ describe('FeishuAdapter', () => {
       await adapter.stop();
     });
 
+    it('normalizes headings and spacing before building card markdown', async () => {
+      await adapter.start();
+      await adapter.send({
+        chatId: 'oc_chat123',
+        text: 'Hello\n## Title\nBody',
+      });
+
+      const call = mockMessageCreate.mock.calls[0][0];
+      const card = JSON.parse(call.data.content);
+      expect(card.body.elements[0].content).toBe('Hello\n\n**Title**\n\nBody');
+      await adapter.stop();
+    });
+
+    it('normalizes direct feishuElements markdown content before sending card', async () => {
+      await adapter.start();
+      await adapter.send({
+        chatId: 'oc_chat123',
+        feishuHeader: { template: 'blue', title: 'Test' },
+        feishuElements: [
+          { tag: 'markdown', content: 'Intro\n## Title\nBody' },
+          { tag: 'hr' },
+        ],
+      });
+
+      const call = mockMessageCreate.mock.calls[0][0];
+      const card = JSON.parse(call.data.content);
+      expect(card.body.elements[0].content).toBe('Intro\n\n**Title**\n\nBody');
+      expect(card.body.elements[1]).toEqual({ tag: 'hr' });
+      await adapter.stop();
+    });
     it('includes action buttons in card when provided', async () => {
       await adapter.start();
       await adapter.send({

--- a/bridge/src/__tests__/markdown.test.ts
+++ b/bridge/src/__tests__/markdown.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { markdownToTelegram, markdownToDiscordChunks, markdownToFeishu, markdownToHtml, truncateLongCodeBlocks } from '../markdown/index.js';
+import { markdownToTelegram, markdownToDiscordChunks, markdownToFeishu, markdownToHtml, truncateLongCodeBlocks, normalizeForIM, normalizeSpacingForIM } from '../markdown/index.js';
 
 describe('Telegram rendering', () => {
+  it('normalizes IM headings and spacing', () => {
+    expect(normalizeForIM('Hello\n## Title\nBody')).toBe('Hello\n\n**Title**\n\nBody');
+    expect(normalizeSpacingForIM('Text\n- item')).toBe('Text\n\n- item');
+  });
+
   it('converts bold', () => {
     expect(markdownToTelegram('**hello**')).toContain('<b>hello</b>');
   });
@@ -71,6 +76,10 @@ describe('Feishu rendering', () => {
   it('passes through markdown unchanged', () => {
     const md = '**bold** and `code`';
     expect(markdownToFeishu(md)).toBe(md);
+  });
+
+  it('shares IM normalization for headings and spacing', () => {
+    expect(normalizeForIM('Intro\n## Title\nBody')).toBe('Intro\n\n**Title**\n\nBody');
   });
 });
 

--- a/bridge/src/__tests__/message-renderer.test.ts
+++ b/bridge/src/__tests__/message-renderer.test.ts
@@ -17,10 +17,11 @@ describe('MessageRenderer', () => {
     vi.useRealTimers();
   });
 
-  function createRenderer(platformLimit = 4096, throttleMs = 300) {
+  function createRenderer(platformLimit = 4096, throttleMs = 300, displayMode: 'compact' | 'verbose' = 'verbose') {
     return new MessageRenderer({
       platformLimit,
       throttleMs,
+      displayMode,
       flushCallback: flushCallback as any,
     });
   }
@@ -61,6 +62,18 @@ describe('MessageRenderer', () => {
       expect(content).toContain('Bash');
       expect(content).toContain('×1');
       expect(content).toContain('1 tools');
+      r.dispose();
+    });
+
+    it('shows compact executing view for weak channels', async () => {
+      const r = createRenderer(4096, 300, 'compact');
+      r.onToolStart('Bash');
+      r.onToolStart('Read');
+      await advance(1300);
+      const content = flushCallback.mock.calls[flushCallback.mock.calls.length - 1][0] as string;
+      expect(content).toContain('⏳ Working… 2 tools · 1s');
+      expect(content).not.toContain('Bash ×1');
+      expect(content).not.toContain('Read ×1');
       r.dispose();
     });
 

--- a/bridge/src/__tests__/sdk-engine.test.ts
+++ b/bridge/src/__tests__/sdk-engine.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SDKEngine } from '../engine/sdk-engine.js';
+import { initBridgeContext } from '../context.js';
+
+function createMockAdapter(channelType = 'telegram') {
+  return {
+    channelType,
+    send: vi.fn().mockResolvedValue({ messageId: 'm1', success: true }),
+    editMessage: vi.fn().mockResolvedValue(undefined),
+    sendTyping: vi.fn().mockResolvedValue(undefined),
+    addReaction: vi.fn().mockResolvedValue(undefined),
+    createThread: vi.fn().mockResolvedValue(undefined),
+  } as any;
+}
+
+describe('SDKEngine working directory healing', () => {
+  let tempRoot: string;
+  let defaultWorkdir: string;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'tlive-sdk-'));
+    defaultWorkdir = join(tempRoot, 'project');
+    mkdirSync(defaultWorkdir, { recursive: true });
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('heals invalid session cwd before live session creation', async () => {
+    const store = {
+      getSession: vi.fn().mockResolvedValue({ id: 's1', workingDirectory: '/', createdAt: '' }),
+      saveSession: vi.fn().mockResolvedValue(undefined),
+      saveMessage: vi.fn().mockResolvedValue(undefined),
+      getMessages: vi.fn().mockResolvedValue([]),
+      acquireLock: vi.fn().mockResolvedValue(true),
+      renewLock: vi.fn().mockResolvedValue(true),
+      releaseLock: vi.fn().mockResolvedValue(undefined),
+      getBinding: vi.fn(),
+      saveBinding: vi.fn(),
+      deleteBinding: vi.fn(),
+      listBindings: vi.fn(),
+      listSessions: vi.fn(),
+      deleteSession: vi.fn(),
+      isDuplicate: vi.fn(),
+      markProcessed: vi.fn(),
+    };
+
+    const liveSession = {
+      isAlive: true,
+      isTurnActive: false,
+      startTurn: vi.fn(() => ({
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ kind: 'query_result', sessionId: 'sdk-1', isError: false, usage: { inputTokens: 1, outputTokens: 1 } });
+            controller.close();
+          },
+        }),
+        controls: undefined,
+      })),
+      close: vi.fn(),
+      steerTurn: vi.fn(),
+    };
+
+    const provider = {
+      capabilities: () => ({ liveSession: true, slashCommands: true, askUserQuestion: true, todoTracking: true, costInUsd: true, skills: true, sessionResume: true }),
+      createSession: vi.fn(() => liveSession),
+      streamChat: vi.fn(),
+    } as any;
+
+    initBridgeContext({
+      defaultWorkdir,
+      store: store as any,
+      llm: provider,
+      permissions: {} as any,
+      core: {} as any,
+    });
+
+    const state = {
+      checkAndUpdateLastActive: vi.fn().mockReturnValue(false),
+      clearThread: vi.fn(),
+      clearSessionWhitelist: vi.fn(),
+      stateKey: vi.fn().mockImplementation((ct: string, id: string) => `${ct}:${id}`),
+      getThread: vi.fn().mockReturnValue(undefined),
+      getPermMode: vi.fn().mockReturnValue('off'),
+      getEffort: vi.fn().mockReturnValue(undefined),
+      getModel: vi.fn().mockReturnValue(undefined),
+      getRuntime: vi.fn().mockReturnValue(undefined),
+    } as any;
+
+    const router = {
+      resolve: vi.fn().mockResolvedValue({ channelType: 'telegram', chatId: 'c1', sessionId: 's1', createdAt: '' }),
+      rebind: vi.fn(),
+    } as any;
+
+    const permissions = {
+      clearSessionWhitelist: vi.fn(),
+      isToolAllowed: vi.fn().mockReturnValue(false),
+      setPendingSdkPerm: vi.fn(),
+      clearPendingSdkPerm: vi.fn(),
+      getGateway: vi.fn().mockReturnValue({ waitFor: vi.fn(), isPending: vi.fn().mockReturnValue(false) }),
+      trackPermissionMessage: vi.fn(),
+      storeQuestionData: vi.fn(),
+    } as any;
+
+    const engine = new SDKEngine(state, router, permissions);
+    const adapter = createMockAdapter();
+
+    await engine.handleMessage(adapter, {
+      channelType: 'telegram',
+      chatId: 'c1',
+      userId: 'u1',
+      text: 'hello',
+      messageId: 'm1',
+    } as any, provider);
+
+    expect(provider.createSession).toHaveBeenCalledWith(expect.objectContaining({ workingDirectory: defaultWorkdir }));
+    expect(store.saveSession).toHaveBeenCalledWith(expect.objectContaining({
+      id: 's1',
+      workingDirectory: defaultWorkdir,
+    }));
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Live turn cwd selection: channelType=telegram chatId=c1 sessionId=s1'));
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining(`effective=${JSON.stringify(defaultWorkdir)} source=defaultWorkdir healed=true reason=root-path`));
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining(`Created LiveSession: registryKey=telegram:c1:${defaultWorkdir}`));
+  });
+});

--- a/bridge/src/__tests__/sdk-engine.test.ts
+++ b/bridge/src/__tests__/sdk-engine.test.ts
@@ -16,6 +16,86 @@ function createMockAdapter(channelType = 'telegram') {
   } as any;
 }
 
+function createStore() {
+  return {
+    getSession: vi.fn().mockResolvedValue({ id: 's1', workingDirectory: '/', createdAt: '' }),
+    saveSession: vi.fn().mockResolvedValue(undefined),
+    saveMessage: vi.fn().mockResolvedValue(undefined),
+    getMessages: vi.fn().mockResolvedValue([]),
+    acquireLock: vi.fn().mockResolvedValue(true),
+    renewLock: vi.fn().mockResolvedValue(true),
+    releaseLock: vi.fn().mockResolvedValue(undefined),
+    getBinding: vi.fn(),
+    saveBinding: vi.fn(),
+    deleteBinding: vi.fn(),
+    listBindings: vi.fn(),
+    listSessions: vi.fn(),
+    deleteSession: vi.fn(),
+    isDuplicate: vi.fn(),
+    markProcessed: vi.fn(),
+  };
+}
+
+function createState() {
+  return {
+    checkAndUpdateLastActive: vi.fn().mockReturnValue(false),
+    clearThread: vi.fn(),
+    clearSessionWhitelist: vi.fn(),
+    stateKey: vi.fn().mockImplementation((ct: string, id: string) => `${ct}:${id}`),
+    getThread: vi.fn().mockReturnValue(undefined),
+    setThread: vi.fn(),
+    getPermMode: vi.fn().mockReturnValue('off'),
+    getEffort: vi.fn().mockReturnValue(undefined),
+    getModel: vi.fn().mockReturnValue(undefined),
+    getRuntime: vi.fn().mockReturnValue(undefined),
+  } as any;
+}
+
+function createRouter(channelType = 'telegram') {
+  return {
+    resolve: vi.fn().mockResolvedValue({ channelType, chatId: 'c1', sessionId: 's1', createdAt: '' }),
+    rebind: vi.fn(),
+  } as any;
+}
+
+function createPermissions() {
+  return {
+    clearSessionWhitelist: vi.fn(),
+    isToolAllowed: vi.fn().mockReturnValue(false),
+    setPendingSdkPerm: vi.fn(),
+    clearPendingSdkPerm: vi.fn(),
+    getGateway: vi.fn().mockReturnValue({ waitFor: vi.fn(), isPending: vi.fn().mockReturnValue(false) }),
+    trackPermissionMessage: vi.fn(),
+    storeQuestionData: vi.fn(),
+  } as any;
+}
+
+function createProvider(events: any[]) {
+  const liveSession = {
+    isAlive: true,
+    isTurnActive: false,
+    startTurn: vi.fn(() => ({
+      stream: new ReadableStream({
+        start(controller) {
+          for (const event of events) controller.enqueue(event);
+          controller.close();
+        },
+      }),
+      controls: undefined,
+    })),
+    close: vi.fn(),
+    steerTurn: vi.fn(),
+  };
+
+  const provider = {
+    capabilities: () => ({ liveSession: true, slashCommands: true, askUserQuestion: true, todoTracking: true, costInUsd: true, skills: true, sessionResume: true }),
+    createSession: vi.fn(() => liveSession),
+    streamChat: vi.fn(),
+  } as any;
+
+  return { provider, liveSession };
+}
+
 describe('SDKEngine working directory healing', () => {
   let tempRoot: string;
   let defaultWorkdir: string;
@@ -37,45 +117,10 @@ describe('SDKEngine working directory healing', () => {
   });
 
   it('heals invalid session cwd before live session creation', async () => {
-    const store = {
-      getSession: vi.fn().mockResolvedValue({ id: 's1', workingDirectory: '/', createdAt: '' }),
-      saveSession: vi.fn().mockResolvedValue(undefined),
-      saveMessage: vi.fn().mockResolvedValue(undefined),
-      getMessages: vi.fn().mockResolvedValue([]),
-      acquireLock: vi.fn().mockResolvedValue(true),
-      renewLock: vi.fn().mockResolvedValue(true),
-      releaseLock: vi.fn().mockResolvedValue(undefined),
-      getBinding: vi.fn(),
-      saveBinding: vi.fn(),
-      deleteBinding: vi.fn(),
-      listBindings: vi.fn(),
-      listSessions: vi.fn(),
-      deleteSession: vi.fn(),
-      isDuplicate: vi.fn(),
-      markProcessed: vi.fn(),
-    };
-
-    const liveSession = {
-      isAlive: true,
-      isTurnActive: false,
-      startTurn: vi.fn(() => ({
-        stream: new ReadableStream({
-          start(controller) {
-            controller.enqueue({ kind: 'query_result', sessionId: 'sdk-1', isError: false, usage: { inputTokens: 1, outputTokens: 1 } });
-            controller.close();
-          },
-        }),
-        controls: undefined,
-      })),
-      close: vi.fn(),
-      steerTurn: vi.fn(),
-    };
-
-    const provider = {
-      capabilities: () => ({ liveSession: true, slashCommands: true, askUserQuestion: true, todoTracking: true, costInUsd: true, skills: true, sessionResume: true }),
-      createSession: vi.fn(() => liveSession),
-      streamChat: vi.fn(),
-    } as any;
+    const store = createStore();
+    const { provider } = createProvider([
+      { kind: 'query_result', sessionId: 'sdk-1', isError: false, usage: { inputTokens: 1, outputTokens: 1 } },
+    ]);
 
     initBridgeContext({
       defaultWorkdir,
@@ -85,32 +130,9 @@ describe('SDKEngine working directory healing', () => {
       core: {} as any,
     });
 
-    const state = {
-      checkAndUpdateLastActive: vi.fn().mockReturnValue(false),
-      clearThread: vi.fn(),
-      clearSessionWhitelist: vi.fn(),
-      stateKey: vi.fn().mockImplementation((ct: string, id: string) => `${ct}:${id}`),
-      getThread: vi.fn().mockReturnValue(undefined),
-      getPermMode: vi.fn().mockReturnValue('off'),
-      getEffort: vi.fn().mockReturnValue(undefined),
-      getModel: vi.fn().mockReturnValue(undefined),
-      getRuntime: vi.fn().mockReturnValue(undefined),
-    } as any;
-
-    const router = {
-      resolve: vi.fn().mockResolvedValue({ channelType: 'telegram', chatId: 'c1', sessionId: 's1', createdAt: '' }),
-      rebind: vi.fn(),
-    } as any;
-
-    const permissions = {
-      clearSessionWhitelist: vi.fn(),
-      isToolAllowed: vi.fn().mockReturnValue(false),
-      setPendingSdkPerm: vi.fn(),
-      clearPendingSdkPerm: vi.fn(),
-      getGateway: vi.fn().mockReturnValue({ waitFor: vi.fn(), isPending: vi.fn().mockReturnValue(false) }),
-      trackPermissionMessage: vi.fn(),
-      storeQuestionData: vi.fn(),
-    } as any;
+    const state = createState();
+    const router = createRouter('telegram');
+    const permissions = createPermissions();
 
     const engine = new SDKEngine(state, router, permissions);
     const adapter = createMockAdapter();
@@ -131,5 +153,153 @@ describe('SDKEngine working directory healing', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Live turn cwd selection: channelType=telegram chatId=c1 sessionId=s1'));
     expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining(`effective=${JSON.stringify(defaultWorkdir)} source=defaultWorkdir healed=true reason=root-path`));
     expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining(`Created LiveSession: registryKey=telegram:c1:${defaultWorkdir}`));
+  });
+});
+
+describe('SDKEngine channel presentation', () => {
+  let tempRoot: string;
+  let defaultWorkdir: string;
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'tlive-sdk-present-'));
+    defaultWorkdir = join(tempRoot, 'project');
+    mkdirSync(defaultWorkdir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('uses compact execution rendering for telegram and normalizes outgoing html', async () => {
+    const store = createStore();
+    const { provider } = createProvider([
+      { kind: 'tool_start', id: 'tu-1', name: 'Bash', input: { command: 'pwd' } },
+      { kind: 'text_delta', text: 'Hello\n## Title\nBody' },
+      { kind: 'query_result', sessionId: 'sdk-1', isError: false, usage: { inputTokens: 1, outputTokens: 1 } },
+    ]);
+
+    initBridgeContext({
+      defaultWorkdir,
+      store: store as any,
+      llm: provider,
+      permissions: {} as any,
+      core: {} as any,
+    });
+
+    const state = createState();
+    const router = createRouter('telegram');
+    const permissions = createPermissions();
+    const engine = new SDKEngine(state, router, permissions);
+    const adapter = createMockAdapter('telegram');
+
+    await engine.handleMessage(adapter, {
+      channelType: 'telegram',
+      chatId: 'c1',
+      userId: 'u1',
+      text: 'hello',
+      messageId: 'm1',
+    } as any, provider);
+
+    expect(adapter.send).toHaveBeenCalledTimes(1);
+    expect(adapter.editMessage).not.toHaveBeenCalled();
+    const sent = adapter.send.mock.calls[0][0];
+    expect(sent.html).toContain('<b>Title</b>');
+    expect(sent.html).toContain('Hello');
+    expect(sent.html).toContain('Body');
+    expect(sent.html).toContain('🖥️ Bash ×1');
+    expect(sent.html).not.toContain('<b>⏳ Working');
+  });
+
+  it('uses multipart intro and labels for telegram adapter send preparation', async () => {
+    const adapter = createMockAdapter('telegram');
+    const longBody = ('## Title\nBody paragraph\n\n').repeat(500);
+
+    const sendPayload = {
+      chatId: 'c1',
+      html: longBody,
+    } as any;
+
+    expect(adapter.send).toHaveBeenCalledTimes(0);
+    await adapter.send(sendPayload);
+    expect(adapter.send).toHaveBeenCalledTimes(1);
+
+    expect(sendPayload.html).toContain('## Title');
+  });
+
+  it('uses verbose execution rendering for feishu and sends normalized plain text', async () => {
+    const store = createStore();
+    const { provider } = createProvider([
+      { kind: 'tool_start', id: 'tu-1', name: 'Bash', input: { command: 'pwd' } },
+      { kind: 'todo_update', todos: [{ content: 'Ship it', status: 'in_progress' }] },
+      { kind: 'text_delta', text: 'Hello\n## Title\nBody' },
+      { kind: 'query_result', sessionId: 'sdk-1', isError: false, usage: { inputTokens: 1, outputTokens: 1 } },
+    ]);
+
+    initBridgeContext({
+      defaultWorkdir,
+      store: store as any,
+      llm: provider,
+      permissions: {} as any,
+      core: {} as any,
+    });
+
+    const state = createState();
+    const router = createRouter('feishu');
+    const permissions = createPermissions();
+    const engine = new SDKEngine(state, router, permissions);
+    const adapter = createMockAdapter('feishu');
+
+    await engine.handleMessage(adapter, {
+      channelType: 'feishu',
+      chatId: 'c1',
+      userId: 'u1',
+      text: 'hello',
+      messageId: 'm1',
+    } as any, provider);
+
+    expect(adapter.send).toHaveBeenCalledTimes(1);
+    expect(adapter.editMessage).not.toHaveBeenCalled();
+    const sent = adapter.send.mock.calls[0][0];
+    expect(sent.text).toContain('Hello');
+    expect(sent.text).toContain('**Title**');
+    expect(sent.text).toContain('Body');
+    expect(sent.text).toContain('🖥️ Bash ×1');
+    expect(sent.text).toContain('📊 1/1 tok');
+  });
+
+  it('normalizes Feishu streaming updates before sending card content', async () => {
+    const store = createStore();
+    const { provider } = createProvider([
+      { kind: 'text_delta', text: 'Hello\n## Title\nBody' },
+      { kind: 'query_result', sessionId: 'sdk-1', isError: false, usage: { inputTokens: 1, outputTokens: 1 } },
+    ]);
+
+    initBridgeContext({
+      defaultWorkdir,
+      store: store as any,
+      llm: provider,
+      permissions: {} as any,
+      core: {} as any,
+    });
+
+    const state = createState();
+    const router = createRouter('feishu');
+    const permissions = createPermissions();
+    const engine = new SDKEngine(state, router, permissions);
+    const adapter = createMockAdapter('feishu');
+
+    await engine.handleMessage(adapter, {
+      channelType: 'feishu',
+      chatId: 'c1',
+      userId: 'u1',
+      text: 'hello',
+      messageId: 'm1',
+    } as any, provider);
+
+    const sent = adapter.send.mock.calls[0][0];
+    expect(sent.text).toContain('Hello');
+    expect(sent.text).toContain('**Title**');
+    expect(sent.text).toContain('Body');
+    expect(sent.text).not.toContain('## Title');
   });
 });

--- a/bridge/src/__tests__/telegram.test.ts
+++ b/bridge/src/__tests__/telegram.test.ts
@@ -192,6 +192,15 @@ describe('TelegramAdapter', () => {
       await adapter.send({ chatId: '12345', text: longText });
       expect(mockSendMessage.mock.calls.length).toBeGreaterThan(1);
     });
+
+    it('adds multipart intro and labels to long messages', async () => {
+      await adapter.start();
+      const longText = ('## Heading\nBody line\n\n').repeat(400);
+      await adapter.send({ chatId: '12345', text: longText });
+      expect(mockSendMessage.mock.calls.length).toBeGreaterThan(1);
+      expect(mockSendMessage.mock.calls[0][1]).toContain('Long reply — split into readable parts.');
+      expect(mockSendMessage.mock.calls[0][1]).toContain('[1/');
+    });
   });
 
   describe('editMessage', () => {

--- a/bridge/src/channels/discord.ts
+++ b/bridge/src/channels/discord.ts
@@ -13,8 +13,9 @@ import {
 import { BaseChannelAdapter, registerAdapterFactory } from './base.js';
 import type { InboundMessage, OutboundMessage, SendResult, FileAttachment } from './types.js';
 import { loadConfig } from '../config.js';
-import { chunkMarkdown } from '../delivery/delivery.js';
+import { prepareMultipartText } from '../delivery/delivery.js';
 import { classifyError } from './errors.js';
+import { normalizeForIM } from '../markdown/index.js';
 import { createUndiciAgent, maskProxyUrl } from '../proxy.js';
 
 interface DiscordConfig {
@@ -26,6 +27,7 @@ interface DiscordConfig {
 
 export class DiscordAdapter extends BaseChannelAdapter {
   readonly channelType = 'discord' as const;
+  private static readonly MULTIPART_INTRO = 'Long reply — split into readable parts.';
   private client: Client | null = null;
   private config: DiscordConfig;
   private messageQueue: InboundMessage[] = [];
@@ -239,8 +241,10 @@ export class DiscordAdapter extends BaseChannelAdapter {
       }
     }
 
-    const content = message.text ?? message.html ?? '';
-    const chunks = chunkMarkdown(content, 2000);
+    const content = normalizeForIM(message.text ?? message.html ?? '');
+    const chunks = prepareMultipartText(content, 2000, {
+      intro: DiscordAdapter.MULTIPART_INTRO,
+    });
 
     let lastSent: Message | undefined;
     try {
@@ -291,7 +295,7 @@ export class DiscordAdapter extends BaseChannelAdapter {
         return;
       }
 
-      const content = message.text ?? message.html ?? '';
+      const content = normalizeForIM(message.text ?? message.html ?? '');
       const truncated = content.length > 2000 ? content.slice(0, 2000) : content;
 
       const payload: Parameters<Message['edit']>[0] = { content: truncated };

--- a/bridge/src/channels/feishu-streaming.ts
+++ b/bridge/src/channels/feishu-streaming.ts
@@ -4,6 +4,8 @@
  * and closes streaming when complete.
  */
 
+import { normalizeForIM } from '../markdown/common.js';
+
 export interface FeishuStreamingOptions {
   client: any; // Lark SDK client
   chatId: string;
@@ -40,6 +42,7 @@ export class FeishuStreamingSession {
 
   /** Create card + send as message. Returns messageId. */
   async start(initialText = 'Thinking...'): Promise<string> {
+    const normalizedInitialText = normalizeForIM(initialText);
     // Step 1: Create card entity with streaming enabled
     const cardJson: Record<string, unknown> = {
       schema: '2.0',
@@ -53,7 +56,7 @@ export class FeishuStreamingSession {
       },
       body: {
         elements: [
-          { tag: 'markdown', content: initialText, element_id: 'content' },
+          { tag: 'markdown', content: normalizedInitialText, element_id: 'content' },
         ],
       },
     };
@@ -97,8 +100,9 @@ export class FeishuStreamingSession {
 
   /** Update the streaming card content (cumulative text). Throttled + serialized. */
   async update(fullText: string): Promise<void> {
-    if (!this.cardId || fullText === this.lastContent) return;
-    this.lastContent = fullText;
+    const normalizedText = normalizeForIM(fullText);
+    if (!this.cardId || normalizedText === this.lastContent) return;
+    this.lastContent = normalizedText;
 
     // Serialize updates to maintain sequence ordering
     this.updateQueue = this.updateQueue.then(async () => {
@@ -113,7 +117,7 @@ export class FeishuStreamingSession {
         await this.client.cardkit.v1.cardElement.content({
           path: { card_id: this.cardId!, element_id: 'content' },
           data: {
-            content: fullText,
+            content: normalizedText,
             sequence: this.sequence,
             uuid: `s_${this.cardId}_${this.sequence}`,
           },

--- a/bridge/src/channels/feishu.ts
+++ b/bridge/src/channels/feishu.ts
@@ -4,6 +4,7 @@ import type { InboundMessage, OutboundMessage, SendResult, FileAttachment } from
 import { loadConfig } from '../config.js';
 import { classifyError } from './errors.js';
 import { markdownToFeishu, downgradeHeadings } from '../markdown/feishu.js';
+import { normalizeForIM } from '../markdown/common.js';
 import { buildFeishuCard } from '../formatting/feishu-card.js';
 import { FeishuStreamingSession } from './feishu-streaming.js';
 import { Readable } from 'node:stream';
@@ -260,8 +261,9 @@ export class FeishuAdapter extends BaseChannelAdapter {
   }
 
   private buildCard(text: string, buttons?: OutboundMessage['buttons'], header?: { template: string; title: string }): string {
+    const normalized = normalizeForIM(text);
     const elements: FeishuCardElement[] = [
-      { tag: 'markdown', content: downgradeHeadings(text) },
+      { tag: 'markdown', content: downgradeHeadings(normalized) },
     ];
 
     if (buttons?.length) {
@@ -390,7 +392,18 @@ export class FeishuAdapter extends BaseChannelAdapter {
       const idType = message.receiveIdType || 'chat_id';
       // If feishuElements provided, build card directly from structured elements
       const cardContent = message.feishuElements
-        ? buildFeishuCard({ header: message.feishuHeader as any, elements: message.feishuElements as any })
+        ? buildFeishuCard({
+          header: message.feishuHeader as any,
+          elements: (message.feishuElements as any[]).map((element) => {
+            if (element?.tag === 'markdown' && typeof element.content === 'string') {
+              return {
+                ...element,
+                content: downgradeHeadings(normalizeForIM(element.content)),
+              };
+            }
+            return element;
+          }),
+        })
         : this.buildCard(raw, message.buttons, message.feishuHeader);
       const data: Record<string, unknown> = {
         receive_id: message.chatId,

--- a/bridge/src/channels/telegram.ts
+++ b/bridge/src/channels/telegram.ts
@@ -6,11 +6,13 @@ import { BaseChannelAdapter, registerAdapterFactory } from './base.js';
 import type { InboundMessage, OutboundMessage, SendResult, FileAttachment } from './types.js';
 import { loadConfig } from '../config.js';
 import { createNodeAgent, maskProxyUrl } from '../proxy.js';
-import { chunkMarkdown } from '../delivery/delivery.js';
+import { prepareMultipartText } from '../delivery/delivery.js';
+import { normalizeForIM } from '../markdown/common.js';
 import { classifyError } from './errors.js';
 
+const TELEGRAM_MULTIPART_INTRO = 'Long reply — split into readable parts.';
+
 interface TelegramConfig {
-  botToken: string;
   chatId: string;
   allowedUsers: string[];
   requireMention: boolean;
@@ -305,8 +307,11 @@ export class TelegramAdapter extends BaseChannelAdapter {
       }
     }
 
-    const text = message.html ?? message.text ?? '';
-    const chunks = text.length > 4096 ? chunkMarkdown(text, 4096) : [text];
+    const rawText = message.html ?? message.text ?? '';
+    const normalizedText = normalizeForIM(rawText);
+    const chunks = prepareMultipartText(normalizedText, 4096, {
+      intro: TELEGRAM_MULTIPART_INTRO,
+    });
 
     let lastMessageId = '';
     try {
@@ -368,7 +373,8 @@ export class TelegramAdapter extends BaseChannelAdapter {
 
   async editMessage(chatId: string, messageId: string, message: OutboundMessage): Promise<void> {
     if (!this.bot) return;
-    const text = message.html ?? message.text ?? '';
+    const rawText = message.html ?? message.text ?? '';
+    const text = normalizeForIM(rawText);
     const opts: Record<string, unknown> = {
       parse_mode: message.html ? 'HTML' : undefined,
     };

--- a/bridge/src/channels/telegram.ts
+++ b/bridge/src/channels/telegram.ts
@@ -2,6 +2,7 @@ import { Bot, InputFile, type Api, type RawApi } from 'grammy';
 import { run, type RunnerHandle } from '@grammyjs/runner';
 import { apiThrottler } from '@grammyjs/transformer-throttler';
 import { createServer, type Server } from 'node:http';
+import { Agent as HttpsAgent } from 'node:https';
 import { BaseChannelAdapter, registerAdapterFactory } from './base.js';
 import type { InboundMessage, OutboundMessage, SendResult, FileAttachment } from './types.js';
 import { loadConfig } from '../config.js';
@@ -13,12 +14,14 @@ import { classifyError } from './errors.js';
 const TELEGRAM_MULTIPART_INTRO = 'Long reply — split into readable parts.';
 
 interface TelegramConfig {
+  botToken: string;
   chatId: string;
   allowedUsers: string[];
   requireMention: boolean;
   webhookUrl: string;
   webhookSecret: string;
   webhookPort: number;
+  pollTimeout: number;
   disableLinkPreview: boolean;
   proxy: string;
 }
@@ -55,10 +58,21 @@ export class TelegramAdapter extends BaseChannelAdapter {
   }
 
   async start(): Promise<void> {
-    const agent = createNodeAgent(this.config.proxy);
-    this.bot = new Bot(this.config.botToken, agent
-      ? { client: { baseFetchConfig: { agent, compress: true } } }
-      : {});
+    const proxyAgent = createNodeAgent(this.config.proxy);
+    const keepAliveAgent = new HttpsAgent({
+      keepAlive: true,
+      maxSockets: 32,
+      keepAliveMsecs: 30_000,
+    });
+    const agent = proxyAgent ?? keepAliveAgent;
+    this.bot = new Bot(this.config.botToken, {
+      client: {
+        baseFetchConfig: {
+          agent,
+          compress: true,
+        },
+      },
+    });
 
     if (this.config.proxy) {
       console.log(`[telegram] Using proxy: ${maskProxyUrl(this.config.proxy)}`);
@@ -234,7 +248,10 @@ export class TelegramAdapter extends BaseChannelAdapter {
       await this.bot.api.deleteWebhook();
       this.runnerHandle = run(this.bot, {
         runner: {
+          maxRetryTime: 24 * 60 * 60 * 1000,
+          retryInterval: 'quadratic',
           fetch: {
+            timeout: Math.max(1, this.config.pollTimeout || 30),
             allowed_updates: ['message', 'callback_query', 'message_reaction'],
           },
         },

--- a/bridge/src/config.ts
+++ b/bridge/src/config.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
@@ -16,6 +16,8 @@ export interface Config {
   enabledChannels: string[];
   runtime: 'claude' | 'codex' | 'auto';
   defaultWorkdir: string;
+  defaultWorkdirSource: 'env' | 'process.cwd';
+  defaultWorkdirDiagnostics: DefaultWorkdirDiagnostics;
   defaultModel: string;
   coreUrl: string;
   /** Claude Code settings sources to load (default: ['user']) */
@@ -85,6 +87,42 @@ function loadEnvFile(path: string): Record<string, string> {
   }
 }
 
+export interface DefaultWorkdirDiagnostics {
+  path: string;
+  source: 'env' | 'process.cwd';
+  envValueProvided: boolean;
+  processCwd: string;
+  isAbsolute: boolean;
+  exists: boolean;
+  isDirectory: boolean;
+  isRootPath: boolean;
+}
+
+function inspectDefaultWorkdir(path: string, source: 'env' | 'process.cwd'): DefaultWorkdirDiagnostics {
+  const processCwd = process.cwd();
+  const isAbsolute = path.startsWith('/');
+  const exists = isAbsolute && existsSync(path);
+  let isDirectory = false;
+  if (exists) {
+    try {
+      isDirectory = statSync(path).isDirectory();
+    } catch {
+      isDirectory = false;
+    }
+  }
+
+  return {
+    path,
+    source,
+    envValueProvided: source === 'env',
+    processCwd,
+    isAbsolute,
+    exists,
+    isDirectory,
+    isRootPath: path === '/',
+  };
+}
+
 export function maskSecret(value: string): string {
   if (!value || value.length <= 4) return '****';
   return '*'.repeat(value.length - 4) + value.slice(-4);
@@ -108,6 +146,9 @@ export function loadConfig(): Config {
 
   const port = parseInt(get('TL_PORT', '4590'), 10);
   const globalProxy = get('TL_PROXY');
+  const defaultWorkdirSource: Config['defaultWorkdirSource'] = process.env.TL_DEFAULT_WORKDIR !== undefined || envFile.TL_DEFAULT_WORKDIR !== undefined ? 'env' : 'process.cwd';
+  const defaultWorkdir = get('TL_DEFAULT_WORKDIR', process.cwd());
+  const defaultWorkdirDiagnostics = inspectDefaultWorkdir(defaultWorkdir, defaultWorkdirSource);
 
   const config: Config = {
     port,
@@ -117,7 +158,9 @@ export function loadConfig(): Config {
     runtime: (get('TL_RUNTIME', 'claude') as Config['runtime']),
     claudeSettingSources: parseList(get('TL_CLAUDE_SETTINGS', 'user')) as ClaudeSettingSource[],
     proxy: globalProxy,
-    defaultWorkdir: get('TL_DEFAULT_WORKDIR', process.cwd()),
+    defaultWorkdir,
+    defaultWorkdirSource,
+    defaultWorkdirDiagnostics,
     defaultModel: get('TL_DEFAULT_MODEL'),
     coreUrl: get('TL_CORE_URL', `http://localhost:${port}`),
     telegram: {

--- a/bridge/src/config.ts
+++ b/bridge/src/config.ts
@@ -36,6 +36,8 @@ export interface Config {
     webhookSecret: string;
     /** Webhook listen port (default: 8443) */
     webhookPort: number;
+    /** Long-poll timeout in seconds for getUpdates (default: 30) */
+    pollTimeout: number;
     /** Disable link previews in outbound messages (default: true) */
     disableLinkPreview: boolean;
     /** HTTP/SOCKS proxy URL — overrides global TL_PROXY */
@@ -171,6 +173,7 @@ export function loadConfig(): Config {
       webhookUrl: get('TL_TG_WEBHOOK_URL'),
       webhookSecret: get('TL_TG_WEBHOOK_SECRET'),
       webhookPort: parseInt(get('TL_TG_WEBHOOK_PORT', '8443'), 10),
+      pollTimeout: parseInt(get('TL_TG_POLL_TIMEOUT', '30'), 10),
       disableLinkPreview: get('TL_TG_DISABLE_LINK_PREVIEW', 'true') !== 'false',
       proxy: get('TL_TG_PROXY') || globalProxy,
     },

--- a/bridge/src/delivery/delivery.ts
+++ b/bridge/src/delivery/delivery.ts
@@ -11,6 +11,85 @@ interface DeliveryOptions {
   paragraphChunk?: boolean;
 }
 
+export interface MultipartTextOptions {
+  intro?: string;
+  labelParts?: boolean;
+}
+
+function isHeading(line: string): boolean {
+  return /^#{1,6}\s+/.test(line.trim());
+}
+
+function isListItem(line: string): boolean {
+  return /^(?:[-*+] |\d+\. )/.test(line.trim());
+}
+
+function splitSemanticBlocks(text: string): string[] {
+  const lines = text.split('\n');
+  const blocks: string[] = [];
+  let current: string[] = [];
+  let inFence = false;
+
+  const flush = () => {
+    if (current.length > 0) {
+      blocks.push(current.join('\n').trimEnd());
+      current = [];
+    }
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    const isFence = /^```/.test(trimmed);
+
+    if (isFence) {
+      current.push(line);
+      inFence = !inFence;
+      if (!inFence) flush();
+      continue;
+    }
+
+    if (inFence) {
+      current.push(line);
+      continue;
+    }
+
+    if (!trimmed) {
+      flush();
+      continue;
+    }
+
+    if (isHeading(trimmed)) {
+      flush();
+      const next = lines[i + 1];
+      if (next && next.trim() && !isHeading(next) && !isListItem(next) && !/^```/.test(next.trim())) {
+        blocks.push(`${line}\n\n${next}`);
+        i++;
+      } else {
+        blocks.push(line);
+      }
+      continue;
+    }
+
+    if (isListItem(trimmed)) {
+      if (current.length > 0 && !isListItem(current[current.length - 1].trim())) {
+        flush();
+      }
+      current.push(line);
+      const next = lines[i + 1];
+      if (!next || !next.trim() || !isListItem(next.trim())) {
+        flush();
+      }
+      continue;
+    }
+
+    current.push(line);
+  }
+
+  flush();
+  return blocks.filter(Boolean);
+}
+
 /**
  * Split text by paragraph boundaries (double newlines) first, then by length.
  * Keeps paragraphs together when possible for better readability.
@@ -18,7 +97,7 @@ interface DeliveryOptions {
 export function chunkByParagraph(text: string, limit: number): string[] {
   if (text.length <= limit) return [text];
 
-  const paragraphs = text.split(/\n{2,}/);
+  const paragraphs = splitSemanticBlocks(text);
   const chunks: string[] = [];
   let current = '';
 
@@ -142,6 +221,34 @@ export function chunkMarkdown(text: string, limit: number, maxLines?: number): s
     }
   }
   return result;
+}
+
+export function labelMultipartChunks(chunks: string[]): string[] {
+  if (chunks.length <= 1) return chunks;
+  return chunks.map((chunk, index) => `[${index + 1}/${chunks.length}]\n${chunk}`);
+}
+
+export function prependMultipartIntro(chunks: string[], intro = 'Long response — sending in parts.'): string[] {
+  if (chunks.length <= 1) return chunks;
+  return chunks.map((chunk, index) => index === 0 ? `${intro}\n\n${chunk}` : chunk);
+}
+
+export function prepareMultipartText(
+  text: string,
+  limit: number,
+  options: MultipartTextOptions = {}
+): string[] {
+  const chunks = chunkByParagraph(text, limit);
+  if (chunks.length <= 1) return chunks;
+
+  let prepared = chunks;
+  if (options.intro) {
+    prepared = prependMultipartIntro(prepared, options.intro);
+  }
+  if (options.labelParts !== false) {
+    prepared = labelMultipartChunks(prepared);
+  }
+  return prepared;
 }
 
 export class DeliveryLayer {

--- a/bridge/src/engine/conversation.ts
+++ b/bridge/src/engine/conversation.ts
@@ -2,6 +2,7 @@ import { getBridgeContext } from '../context.js';
 import type { CanonicalEvent } from '../messages/schema.js';
 import type { LLMProvider, FileAttachment, PermissionRequestHandler, QueryControls, StreamChatResult } from '../providers/base.js';
 import type { AskUserQuestionHandler } from '../messages/types.js';
+import { resolveWorkingDirectory } from './working-directory.js';
 
 const TEXT_MIME_PREFIXES = ['text/', 'application/json', 'application/xml', 'application/javascript', 'application/typescript', 'application/x-yaml', 'application/toml'];
 
@@ -91,7 +92,22 @@ export class ConversationEngine {
       // 4. Get session info — use config's defaultWorkdir instead of process.cwd()
       //    (bridge daemon CWD may differ from user's project directory)
       const session = await store.getSession(params.sessionId);
-      const workDir = session?.workingDirectory ?? defaultWorkdir;
+      const cwdResolution = resolveWorkingDirectory({
+        sessionWorkdir: session?.workingDirectory,
+        defaultWorkdir,
+      });
+      const workDir = cwdResolution.effectiveWorkdir;
+      if (cwdResolution.healingOccurred) {
+        console.warn(`[tlive:engine] Healed session working directory for ${params.sessionId}: stored=${JSON.stringify(session?.workingDirectory)} effective=${JSON.stringify(workDir)} source=${cwdResolution.source} reason=${cwdResolution.reason}`);
+        await store.saveSession({
+          id: params.sessionId,
+          workingDirectory: workDir,
+          createdAt: session?.createdAt ?? new Date().toISOString(),
+          sdkSessionId: session?.sdkSessionId,
+          model: session?.model,
+          mode: session?.mode,
+        });
+      }
 
       // 5. Stream LLM response — use pre-built stream from LiveSession or call streamChat
       const result = params.streamResult ?? llm.streamChat({
@@ -136,9 +152,11 @@ export class ConversationEngine {
               const existing = await store.getSession(params.sessionId);
               await store.saveSession({
                 id: params.sessionId,
-                workingDirectory: existing?.workingDirectory ?? defaultWorkdir,
+                workingDirectory: existing?.workingDirectory ?? workDir,
                 createdAt: existing?.createdAt ?? new Date().toISOString(),
                 sdkSessionId: value.sessionId,
+                model: existing?.model,
+                mode: existing?.mode,
               });
             }
             params.onQueryResult?.(value);

--- a/bridge/src/engine/message-renderer.ts
+++ b/bridge/src/engine/message-renderer.ts
@@ -51,6 +51,10 @@ export class MessageRenderer {
   private flushing = false;
   private pendingFlush = false;
 
+  private getSafeResponseText(): string {
+    return typeof this.responseText === 'string' ? this.responseText : '';
+  }
+
   get messageId(): string | undefined {
     return this._messageId;
   }
@@ -132,6 +136,7 @@ export class MessageRenderer {
   }
 
   onTextDelta(text: string): void {
+    if (typeof text !== 'string' || !text) return;
     this.responseText += text;
     this.scheduleFlush();
   }
@@ -186,14 +191,15 @@ export class MessageRenderer {
   }
 
   private renderExecuting(): string {
-    if (this.totalTools === 0 && !this.responseText) {
+    const responseText = this.getSafeResponseText();
+    if (this.totalTools === 0 && !responseText) {
       return '⏳ Starting...';
     }
     const lines: string[] = [];
 
     // Show response text above status line if available
-    if (this.responseText.trim()) {
-      lines.push(this.responseText.trim());
+    if (responseText.trim()) {
+      lines.push(responseText.trim());
       lines.push('');
     }
 
@@ -238,8 +244,9 @@ export class MessageRenderer {
 
     // Error with tools — show partial text + stopped + footer
     if (this.errorMessage) {
-      if (this.responseText) {
-        lines.push(this.responseText);
+      const responseText = this.getSafeResponseText();
+      if (responseText) {
+        lines.push(responseText);
       }
       lines.push('⚠️ Stopped');
       lines.push(SEPARATOR);
@@ -253,9 +260,10 @@ export class MessageRenderer {
     }
 
     // Completed — no platform limit applied here; bridge-manager handles overflow chunking
-    if (this.responseText) {
+    const responseText = this.getSafeResponseText();
+    if (responseText) {
       // Ensure text ends cleanly before separator (strip trailing whitespace but keep content)
-      lines.push(this.responseText.trimEnd());
+      lines.push(responseText.trimEnd());
       lines.push(SEPARATOR);
     }
     if (this.totalTools > 0) {

--- a/bridge/src/engine/message-renderer.ts
+++ b/bridge/src/engine/message-renderer.ts
@@ -5,6 +5,7 @@ import { getToolIcon } from './tool-registry.js';
 export interface MessageRendererOptions {
   platformLimit: number;
   throttleMs?: number;
+  displayMode?: 'compact' | 'verbose';
   flushCallback: (
     content: string,
     isEdit: boolean,
@@ -46,6 +47,7 @@ export class MessageRenderer {
   private elapsedSeconds = 0;
   private platformLimit: number;
   private throttleMs: number;
+  private displayMode: 'compact' | 'verbose';
   private flushCallback: MessageRendererOptions['flushCallback'];
   private onPermissionTimeout?: MessageRendererOptions['onPermissionTimeout'];
   private flushing = false;
@@ -62,6 +64,7 @@ export class MessageRenderer {
   constructor(options: MessageRendererOptions) {
     this.platformLimit = options.platformLimit;
     this.throttleMs = options.throttleMs ?? 300;
+    this.displayMode = options.displayMode ?? 'verbose';
     this.flushCallback = options.flushCallback;
     this.onPermissionTimeout = options.onPermissionTimeout;
   }
@@ -191,6 +194,32 @@ export class MessageRenderer {
   }
 
   private renderExecuting(): string {
+    return this.displayMode === 'compact'
+      ? this.renderExecutingCompact()
+      : this.renderExecutingVerbose();
+  }
+
+  private renderExecutingCompact(): string {
+    const responseText = this.getSafeResponseText();
+    if (this.totalTools === 0 && !responseText) {
+      return '⏳ Starting...';
+    }
+
+    const lines: string[] = [];
+    if (responseText.trim()) {
+      lines.push(responseText.trim());
+      lines.push('');
+    }
+
+    if (this.totalTools > 0) {
+      const toolNoun = this.totalTools === 1 ? 'tool' : 'tools';
+      lines.push(`⏳ Working… ${this.totalTools} ${toolNoun} · ${this.elapsedSeconds}s`);
+    }
+
+    return this.applyPlatformLimit(redactSensitiveContent(lines.join('\n')));
+  }
+
+  private renderExecutingVerbose(): string {
     const responseText = this.getSafeResponseText();
     if (this.totalTools === 0 && !responseText) {
       return '⏳ Starting...';
@@ -249,21 +278,28 @@ export class MessageRenderer {
         lines.push(responseText);
       }
       lines.push('⚠️ Stopped');
-      lines.push(SEPARATOR);
-      if (this.totalTools > 0) {
-        lines.push(this.renderToolSummary());
-      }
-      if (this.costLine) {
-        lines.push(this.costLine);
-      }
+      lines.push(...this.renderFooterLines());
       return this.applyPlatformLimit(redactSensitiveContent(lines.join('\n')));
     }
 
-    // Completed — no platform limit applied here; bridge-manager handles overflow chunking
+    lines.push(...this.renderAnswerLines());
+    lines.push(...this.renderFooterLines());
+    return redactSensitiveContent(lines.join('\n'));
+  }
+
+  private renderAnswerLines(): string[] {
+    const lines: string[] = [];
     const responseText = this.getSafeResponseText();
     if (responseText) {
-      // Ensure text ends cleanly before separator (strip trailing whitespace but keep content)
       lines.push(responseText.trimEnd());
+    }
+    return lines;
+  }
+
+  private renderFooterLines(): string[] {
+    const lines: string[] = [];
+    const hasAnswer = !!this.getSafeResponseText();
+    if (hasAnswer || this.errorMessage) {
       lines.push(SEPARATOR);
     }
     if (this.totalTools > 0) {
@@ -272,7 +308,7 @@ export class MessageRenderer {
     if (this.costLine) {
       lines.push(this.costLine);
     }
-    return redactSensitiveContent(lines.join('\n'));
+    return lines;
   }
 
   private applyPlatformLimit(content: string): string {

--- a/bridge/src/engine/permission-coordinator.ts
+++ b/bridge/src/engine/permission-coordinator.ts
@@ -75,6 +75,7 @@ export class PermissionCoordinator {
 
   /** Parse text as a permission decision */
   parsePermissionText(text: string): string | null {
+    if (typeof text !== 'string') return null;
     const t = text.trim().toLowerCase();
     if (['allow', 'a', 'yes', 'y', '允许', '通过'].includes(t)) return 'allow';
     if (['deny', 'd', 'no', 'n', '拒绝', '否'].includes(t)) return 'deny';

--- a/bridge/src/engine/router.ts
+++ b/bridge/src/engine/router.ts
@@ -2,11 +2,31 @@ import { getBridgeContext } from '../context.js';
 import type { ChannelBinding } from '../store/interface.js';
 
 export class ChannelRouter {
+  private async ensureSession(sessionId: string, createdAt: string): Promise<void> {
+    const { store, defaultWorkdir } = getBridgeContext();
+    const session = await store.getSession(sessionId);
+    if (session) {
+      console.log(`[tlive:router] Session already exists: sessionId=${sessionId} workingDirectory=${JSON.stringify(session.workingDirectory)}`);
+      return;
+    }
+
+    await store.saveSession({
+      id: sessionId,
+      workingDirectory: defaultWorkdir,
+      createdAt,
+    });
+    console.log(`[tlive:router] Seeded missing session: sessionId=${sessionId} status=missing defaultWorkdir=${JSON.stringify(defaultWorkdir)}`);
+  }
+
   async resolve(channelType: string, chatId: string): Promise<ChannelBinding> {
     const { store } = getBridgeContext();
 
     let binding = await store.getBinding(channelType, chatId);
-    if (binding) return binding;
+    if (binding) {
+      console.log(`[tlive:router] Reusing binding: channelType=${channelType} chatId=${chatId} sessionId=${binding.sessionId} createdAt=${binding.createdAt}`);
+      await this.ensureSession(binding.sessionId, binding.createdAt);
+      return binding;
+    }
 
     // Auto-create binding for first message
     binding = {
@@ -16,6 +36,8 @@ export class ChannelRouter {
       createdAt: new Date().toISOString(),
     };
     await store.saveBinding(binding);
+    console.log(`[tlive:router] Auto-created binding: channelType=${channelType} chatId=${chatId} sessionId=${binding.sessionId} createdAt=${binding.createdAt}`);
+    await this.ensureSession(binding.sessionId, binding.createdAt);
     return binding;
   }
 
@@ -28,6 +50,8 @@ export class ChannelRouter {
       createdAt: new Date().toISOString(),
     };
     await store.saveBinding(binding);
+    console.log(`[tlive:router] Rebound chat: channelType=${channelType} chatId=${chatId} sessionId=${binding.sessionId} createdAt=${binding.createdAt}`);
+    await this.ensureSession(binding.sessionId, binding.createdAt);
     return binding;
   }
 }

--- a/bridge/src/engine/sdk-engine.ts
+++ b/bridge/src/engine/sdk-engine.ts
@@ -15,6 +15,7 @@ import { downgradeHeadings } from '../markdown/feishu.js';
 import { chunkByParagraph } from '../delivery/delivery.js';
 import type { FeishuStreamingSession } from '../channels/feishu-streaming.js';
 import { getBridgeContext } from '../context.js';
+import { resolveWorkingDirectory } from './working-directory.js';
 
 /** Managed session — wraps a LiveSession with per-chat metadata */
 interface ManagedSession {
@@ -97,7 +98,10 @@ export class SDKEngine {
   ): ManagedSession | null {
     const key = this.sessionKey(channelType, chatId, workdir);
     const existing = this.registry.get(key);
-    if (existing?.session.isAlive) return existing;
+    if (existing?.session.isAlive) {
+      console.log(`[tlive:engine] Reusing LiveSession: registryKey=${key} workdir=${JSON.stringify(workdir)} sdkSessionId=${sdkSessionId ?? 'new'} existingAlive=${existing.session.isAlive}`);
+      return existing;
+    }
 
     // Clean up dead session
     if (existing) this.registry.delete(key);
@@ -109,7 +113,7 @@ export class SDKEngine {
       const session = provider.createSession({ workingDirectory: workdir, sessionId: sdkSessionId, effort: opts?.effort, model: opts?.model });
       const managed: ManagedSession = { session, workdir, costTracker: new CostTracker(), lastActiveAt: Date.now() };
       this.registry.set(key, managed);
-      console.log(`[tlive:engine] Created LiveSession for ${key}`);
+      console.log(`[tlive:engine] Created LiveSession: registryKey=${key} workdir=${JSON.stringify(workdir)} resumedSdkSessionId=${sdkSessionId ?? 'new'}`);
       return managed;
     } catch (err) {
       console.error(`[tlive:engine] Failed to create LiveSession for ${key}:`, err);
@@ -356,7 +360,29 @@ export class SDKEngine {
     // Resolve working directory
     const { store, defaultWorkdir } = getBridgeContext();
     const session = await store.getSession(binding.sessionId);
-    const workdir = session?.workingDirectory ?? defaultWorkdir;
+    const cwdResolution = resolveWorkingDirectory({
+      sessionWorkdir: session?.workingDirectory,
+      defaultWorkdir,
+    });
+    const workdir = cwdResolution.effectiveWorkdir;
+    console.log(
+      `[tlive:engine] Live turn cwd selection: channelType=${msg.channelType} chatId=${msg.chatId} ` +
+      `sessionId=${binding.sessionId} sessionExists=${session ? 'yes' : 'no'} ` +
+      `stored=${JSON.stringify(session?.workingDirectory)} defaultWorkdir=${JSON.stringify(defaultWorkdir)} ` +
+      `effective=${JSON.stringify(workdir)} source=${cwdResolution.source} ` +
+      `healed=${cwdResolution.healingOccurred} reason=${cwdResolution.reason}`
+    );
+    if (cwdResolution.healingOccurred) {
+      console.warn(`[tlive:engine] Healed live session working directory for ${binding.sessionId} (${msg.channelType}:${msg.chatId}): stored=${JSON.stringify(session?.workingDirectory)} effective=${JSON.stringify(workdir)} source=${cwdResolution.source} reason=${cwdResolution.reason}`);
+      await store.saveSession({
+        id: binding.sessionId,
+        workingDirectory: workdir,
+        createdAt: session?.createdAt ?? binding.createdAt,
+        sdkSessionId: session?.sdkSessionId,
+        model: session?.model,
+        mode: session?.mode,
+      });
+    }
 
     // Resolve threadId
     let threadId = msg.threadId;

--- a/bridge/src/engine/sdk-engine.ts
+++ b/bridge/src/engine/sdk-engine.ts
@@ -10,9 +10,9 @@ import { MessageRenderer } from './message-renderer.js';
 import { CostTracker } from './cost-tracker.js';
 import type { UsageStats } from './cost-tracker.js';
 import { getToolCommand } from './tool-registry.js';
-import { markdownToTelegram } from '../markdown/index.js';
+import { markdownToTelegram, normalizeForIM } from '../markdown/index.js';
 import { downgradeHeadings } from '../markdown/feishu.js';
-import { chunkByParagraph } from '../delivery/delivery.js';
+import { chunkByParagraph, prepareMultipartText } from '../delivery/delivery.js';
 import type { FeishuStreamingSession } from '../channels/feishu-streaming.js';
 import { getBridgeContext } from '../context.js';
 import { resolveWorkingDirectory } from './working-directory.js';
@@ -394,6 +394,7 @@ export class SDKEngine {
     }
 
     const reactionChatId = msg.chatId;
+    const weakChannelMultipartIntro = 'Long reply — split into readable parts.';
 
     // Start typing heartbeat
     const typingTarget = threadId && adapter.channelType === 'discord' ? threadId : msg.chatId;
@@ -420,6 +421,7 @@ export class SDKEngine {
     const renderer = new MessageRenderer({
       platformLimit: platformLimits[adapter.channelType] ?? 4096,
       throttleMs: 300,
+      displayMode: adapter.channelType === 'feishu' ? 'verbose' : 'compact',
       onPermissionTimeout: async (toolName, input, buttons) => {
         permissionReminderTool = toolName;
         permissionReminderInput = input;
@@ -436,27 +438,28 @@ export class SDKEngine {
         } catch { /* non-fatal */ }
       },
       flushCallback: async (content, isEdit, buttons) => {
+        const normalizedContent = normalizeForIM(content);
         if (feishuSession && !buttons?.length) {
           if (!isEdit) {
             try {
-              const messageId = await feishuSession.start(downgradeHeadings(content));
+              const messageId = await feishuSession.start(downgradeHeadings(normalizedContent));
               clearInterval(typingInterval);
               return messageId;
             } catch {
               feishuSession = null;
             }
           } else {
-            feishuSession.update(downgradeHeadings(content)).catch(() => {});
+            feishuSession.update(downgradeHeadings(normalizedContent)).catch(() => {});
             return;
           }
         }
         let outMsg: OutboundMessage;
         if (adapter.channelType === 'telegram') {
-          outMsg = { chatId: msg.chatId, html: markdownToTelegram(content), threadId };
+          outMsg = { chatId: msg.chatId, html: markdownToTelegram(normalizedContent), threadId };
         } else if (adapter.channelType === 'discord') {
-          outMsg = { chatId: msg.chatId, text: content, threadId };
+          outMsg = { chatId: msg.chatId, text: normalizedContent, threadId };
         } else {
-          outMsg = { chatId: msg.chatId, text: content };
+          outMsg = { chatId: msg.chatId, text: normalizedContent };
         }
         if (buttons?.length) {
           outMsg.buttons = buttons.map(b => ({ ...b, style: b.style as 'primary' | 'danger' | 'default' }));
@@ -478,8 +481,10 @@ export class SDKEngine {
           return result.messageId;
         } else {
           const limit = platformLimits[adapter.channelType] ?? 4096;
-          if (content.length > limit) {
-            const chunks = chunkByParagraph(content, limit);
+          if (normalizedContent.length > limit) {
+            const chunks = adapter.channelType === 'telegram' || adapter.channelType === 'discord'
+              ? prepareMultipartText(normalizedContent, limit, { intro: weakChannelMultipartIntro })
+              : chunkByParagraph(normalizedContent, limit);
             const firstOutMsg: OutboundMessage = adapter.channelType === 'telegram'
               ? { chatId: msg.chatId, html: markdownToTelegram(chunks[0]), threadId }
               : adapter.channelType === 'discord'

--- a/bridge/src/engine/working-directory.ts
+++ b/bridge/src/engine/working-directory.ts
@@ -1,0 +1,85 @@
+import { existsSync, statSync } from 'node:fs';
+
+export type WorkingDirectorySource = 'session' | 'defaultWorkdir' | 'process.cwd';
+export type WorkingDirectoryReason =
+  | 'valid'
+  | 'missing'
+  | 'non-string'
+  | 'empty'
+  | 'non-absolute'
+  | 'nonexistent'
+  | 'not-directory'
+  | 'root-path';
+
+export interface WorkingDirectoryResolution {
+  effectiveWorkdir: string;
+  source: WorkingDirectorySource;
+  healingOccurred: boolean;
+  reason: WorkingDirectoryReason;
+  storedWorkdir?: string;
+}
+
+function validateCandidate(candidate: unknown, defaultWorkdir: string): { valid: boolean; reason: WorkingDirectoryReason } {
+  if (candidate === undefined || candidate === null) return { valid: false, reason: 'missing' };
+  if (typeof candidate !== 'string') return { valid: false, reason: 'non-string' };
+  const trimmed = candidate.trim();
+  if (!trimmed) return { valid: false, reason: 'empty' };
+  if (!trimmed.startsWith('/')) return { valid: false, reason: 'non-absolute' };
+  if (trimmed === '/' && defaultWorkdir !== '/') return { valid: false, reason: 'root-path' };
+  if (!existsSync(trimmed)) return { valid: false, reason: 'nonexistent' };
+  try {
+    if (!statSync(trimmed).isDirectory()) return { valid: false, reason: 'not-directory' };
+  } catch {
+    return { valid: false, reason: 'nonexistent' };
+  }
+  return { valid: true, reason: 'valid' };
+}
+
+export function resolveWorkingDirectory(input: {
+  sessionWorkdir?: unknown;
+  defaultWorkdir: string;
+  processWorkdir?: string;
+}): WorkingDirectoryResolution {
+  const storedWorkdir = typeof input.sessionWorkdir === 'string' ? input.sessionWorkdir : undefined;
+  const sessionValidation = validateCandidate(input.sessionWorkdir, input.defaultWorkdir);
+  if (sessionValidation.valid) {
+    return {
+      effectiveWorkdir: input.sessionWorkdir as string,
+      source: 'session',
+      healingOccurred: false,
+      reason: 'valid',
+      storedWorkdir,
+    };
+  }
+
+  const defaultValidation = validateCandidate(input.defaultWorkdir, input.defaultWorkdir);
+  if (defaultValidation.valid) {
+    return {
+      effectiveWorkdir: input.defaultWorkdir,
+      source: 'defaultWorkdir',
+      healingOccurred: true,
+      reason: sessionValidation.reason,
+      storedWorkdir,
+    };
+  }
+
+  const fallbackProcessWorkdir = input.processWorkdir ?? process.cwd();
+  const processValidation = validateCandidate(fallbackProcessWorkdir, input.defaultWorkdir);
+  if (processValidation.valid) {
+    return {
+      effectiveWorkdir: fallbackProcessWorkdir,
+      source: 'process.cwd',
+      healingOccurred: true,
+      reason: sessionValidation.reason,
+      storedWorkdir,
+    };
+  }
+
+  return {
+    effectiveWorkdir: fallbackProcessWorkdir,
+    source: 'process.cwd',
+    healingOccurred: true,
+    reason: sessionValidation.reason,
+    storedWorkdir,
+  };
+}

--- a/bridge/src/formatting/notification.ts
+++ b/bridge/src/formatting/notification.ts
@@ -2,6 +2,7 @@ import type { ChannelType, OutboundMessage } from '../channels/types.js';
 import type { NotificationData } from './types.js';
 import { markdownToTelegram } from '../markdown/telegram.js';
 import { downgradeHeadings } from '../markdown/feishu.js';
+import { normalizeForIM } from '../markdown/common.js';
 
 interface NotificationMessage {
   text?: string;
@@ -87,7 +88,7 @@ export function formatNotification(data: NotificationData, channelType: ChannelT
       const elements: Array<Record<string, unknown>> = [];
       if (summary) {
         // Downgrade ## headings to bold — Card renders headings too large
-        elements.push({ tag: 'markdown', content: downgradeHeadings(summary) });
+        elements.push({ tag: 'markdown', content: downgradeHeadings(normalizeForIM(summary)) });
       }
       if (data.terminalUrl) {
         elements.push({ tag: 'hr' });

--- a/bridge/src/main.ts
+++ b/bridge/src/main.ts
@@ -139,6 +139,18 @@ async function main() {
 
   logger.info('TLive Bridge starting...');
   logger.info(`Enabled channels: ${config.enabledChannels.join(', ') || 'none'}`);
+  logger.info(`Bridge startup context: defaultWorkdir=${JSON.stringify(config.defaultWorkdir)} source=${config.defaultWorkdirSource} processCwd=${JSON.stringify(config.defaultWorkdirDiagnostics.processCwd)}`);
+  if (config.defaultWorkdirDiagnostics.isRootPath || !config.defaultWorkdirDiagnostics.isAbsolute || !config.defaultWorkdirDiagnostics.exists || !config.defaultWorkdirDiagnostics.isDirectory) {
+    logger.warn(
+      `Suspicious defaultWorkdir detected: path=${JSON.stringify(config.defaultWorkdirDiagnostics.path)} ` +
+      `source=${config.defaultWorkdirDiagnostics.source} ` +
+      `processCwd=${JSON.stringify(config.defaultWorkdirDiagnostics.processCwd)} ` +
+      `isAbsolute=${config.defaultWorkdirDiagnostics.isAbsolute} ` +
+      `exists=${config.defaultWorkdirDiagnostics.exists} ` +
+      `isDirectory=${config.defaultWorkdirDiagnostics.isDirectory} ` +
+      `isRootPath=${config.defaultWorkdirDiagnostics.isRootPath}`
+    );
+  }
 
   // Write startup status
   writeStatusFile(tliveHome, {

--- a/bridge/src/markdown/common.ts
+++ b/bridge/src/markdown/common.ts
@@ -1,0 +1,20 @@
+export function normalizeSpacingForIM(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/\t/g, '  ')
+    .replace(/([^\n])\n(#{1,6}\s)/g, '$1\n\n$2')
+    .replace(/(#{1,6}\s.+)\n([^\n#`\-*+]|\d+\.)/g, '$1\n\n$2')
+    .replace(/([^\n])\n(```)/g, '$1\n\n$2')
+    .replace(/(```)\n([^\n])/g, '$1\n\n$2')
+    .replace(/([^\n])\n((?:[-*+] |\d+\. ))/g, '$1\n\n$2')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+export function normalizeHeadingsForIM(text: string): string {
+  return text.replace(/^#{1,6}\s+(.+)$/gm, '**$1**');
+}
+
+export function normalizeForIM(text: string): string {
+  return normalizeHeadingsForIM(normalizeSpacingForIM(text));
+}

--- a/bridge/src/markdown/feishu.ts
+++ b/bridge/src/markdown/feishu.ts
@@ -1,3 +1,5 @@
+import { normalizeHeadingsForIM, normalizeSpacingForIM } from './common.js';
+
 export function markdownToFeishu(text: string): string {
   let result = text;
   result = result.replace(/<b>(.*?)<\/b>/g, '**$1**');
@@ -16,9 +18,5 @@ export function markdownToFeishu(text: string): string {
  * Ensures a blank line before each heading for proper spacing.
  */
 export function downgradeHeadings(text: string): string {
-  // Ensure blank line before heading lines (unless already blank or start of text)
-  let result = text.replace(/([^\n])\n(#{1,6}\s)/g, '$1\n\n$2');
-  // Convert headings to bold
-  result = result.replace(/^#{1,6}\s+(.+)$/gm, '**$1**');
-  return result;
+  return normalizeHeadingsForIM(normalizeSpacingForIM(text));
 }

--- a/bridge/src/markdown/index.ts
+++ b/bridge/src/markdown/index.ts
@@ -2,3 +2,4 @@ export { markdownToHtml, truncateLongCodeBlocks } from './ir.js';
 export { markdownToTelegram } from './telegram.js';
 export { markdownToDiscordChunks } from './discord.js';
 export { markdownToFeishu } from './feishu.js';
+export { normalizeForIM, normalizeHeadingsForIM, normalizeSpacingForIM } from './common.js';

--- a/config.env.example
+++ b/config.env.example
@@ -21,6 +21,9 @@ TL_TG_CHAT_ID=
 TL_TG_ALLOWED_USERS=
 # Require @mention in groups (default: true)
 TL_TG_REQUIRE_MENTION=true
+# Long-poll timeout seconds for getUpdates (default: 30)
+# Lower this (e.g. 10) if your network frequently resets long-lived Telegram connections
+# TL_TG_POLL_TIMEOUT=10
 # Disable link previews in messages (default: true)
 TL_TG_DISABLE_LINK_PREVIEW=true
 # Webhook mode (optional — omit to use long-polling)

--- a/core/cmd/tlive/run.go
+++ b/core/cmd/tlive/run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/termlive/termlive/core/internal/config"
 	"github.com/termlive/termlive/core/internal/daemon"
+	"github.com/termlive/termlive/core/internal/notify"
 	"github.com/termlive/termlive/core/internal/server"
 	"github.com/termlive/termlive/core/web"
 	"golang.org/x/term"
@@ -92,10 +93,14 @@ func runCommand(cmd *cobra.Command, args []string) error {
 func runHost(cfg *config.Config, args []string, rows, cols uint16, lockPath string) error {
 	// Create daemon
 	d := daemon.NewDaemon(daemon.DaemonConfig{
-		Port:  cfg.Daemon.Port,
-		Token: cfg.Daemon.Token,
-		Host:  cfg.Daemon.Host,
+		Port:          cfg.Daemon.Port,
+		Token:         cfg.Daemon.Token,
+		Host:          cfg.Daemon.Host,
+		WeChatWebhook: cfg.Daemon.WeChatWebhook,
 	})
+	if wechat := notify.NewWeChatNotifier(cfg.Daemon.WeChatWebhook); wechat != nil {
+		d.SetNotifiers(notify.NewMultiNotifier(wechat))
+	}
 	mgr := d.Manager()
 
 	// Start reaper to clean up orphaned client-mode sessions (e.g. killed by timeout)

--- a/core/internal/config/config.go
+++ b/core/internal/config/config.go
@@ -15,9 +15,10 @@ type Config struct {
 
 // DaemonConfig holds settings for the background daemon process.
 type DaemonConfig struct {
-	Port  int
-	Token string
-	Host  string
+	Port           int
+	Token          string
+	Host           string
+	WeChatWebhook  string
 }
 
 // Default returns a Config with sensible defaults.
@@ -32,7 +33,7 @@ func Default() *Config {
 
 // LoadFromEnv reads ~/.tlive/config.env (KEY=VALUE format) and returns a Config.
 // Missing keys fall back to defaults. If the file does not exist, defaults are returned.
-// Supported keys: TL_PORT, TL_TOKEN, TL_HOST.
+// Supported keys: TL_PORT, TL_TOKEN, TL_HOST, TL_WECHAT_WEBHOOK.
 func LoadFromEnv() (*Config, error) {
 	cfg := Default()
 
@@ -76,6 +77,8 @@ func LoadFromEnv() (*Config, error) {
 			cfg.Daemon.Token = val
 		case "TL_HOST":
 			cfg.Daemon.Host = val
+		case "TL_WECHAT_WEBHOOK":
+			cfg.Daemon.WeChatWebhook = val
 		}
 	}
 	return cfg, scanner.Err()

--- a/core/internal/config/config_test.go
+++ b/core/internal/config/config_test.go
@@ -40,7 +40,7 @@ func TestLoadFromEnv_Values(t *testing.T) {
 	if err := os.MkdirAll(cfgDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	content := "TL_PORT=9090\nTL_TOKEN=my-token\nTL_HOST=127.0.0.1\n"
+	content := "TL_PORT=9090\nTL_TOKEN=my-token\nTL_HOST=127.0.0.1\nTL_WECHAT_WEBHOOK=https://example.test/wechat\n"
 	if err := os.WriteFile(filepath.Join(cfgDir, "config.env"), []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -57,6 +57,9 @@ func TestLoadFromEnv_Values(t *testing.T) {
 	}
 	if cfg.Daemon.Host != "127.0.0.1" {
 		t.Errorf("expected host '127.0.0.1', got %q", cfg.Daemon.Host)
+	}
+	if cfg.Daemon.WeChatWebhook != "https://example.test/wechat" {
+		t.Errorf("expected WeChat webhook to load, got %q", cfg.Daemon.WeChatWebhook)
 	}
 }
 

--- a/core/internal/daemon/daemon.go
+++ b/core/internal/daemon/daemon.go
@@ -15,14 +15,17 @@ import (
 	"sync"
 	"time"
 	"unicode/utf8"
+
+	"github.com/termlive/termlive/core/internal/notify"
 )
 
 // DaemonConfig holds configuration for the daemon HTTP server.
 type DaemonConfig struct {
-	Port         int
-	Token        string
-	Host         string // default "0.0.0.0"
-	HistoryLimit int
+	Port          int
+	Token         string
+	Host          string // default "0.0.0.0"
+	HistoryLimit  int
+	WeChatWebhook string
 }
 
 // Daemon is the TermLive session hub. It manages PTY sessions and exposes
@@ -32,6 +35,7 @@ type Daemon struct {
 	mgr           *SessionManager
 	notifications *NotificationStore
 	hooks         *HookManager
+	notifier      *notify.MultiNotifier
 	token         string
 	host          string
 	startTime     time.Time
@@ -75,6 +79,11 @@ func (d *Daemon) Token() string { return d.token }
 
 // Notifications returns the notification store (for direct internal use).
 func (d *Daemon) Notifications() *NotificationStore { return d.notifications }
+
+// SetNotifiers configures external notification channels (WeChat, etc.).
+func (d *Daemon) SetNotifiers(n *notify.MultiNotifier) {
+	d.notifier = n
+}
 
 // SetExtraHandler sets an additional HTTP handler that serves routes
 // not handled by the daemon's own API (e.g., Web UI, WebSocket).
@@ -480,7 +489,110 @@ func (d *Daemon) handleHookNotify(w http.ResponseWriter, r *http.Request) {
 	}
 
 	d.notifications.Add(NotifyProgress, string(rawBody), "")
+	if d.notifier != nil && d.notifier.Len() > 0 {
+		relayMsg := d.buildRelayNotifyMessage(hookData, rawBody)
+		if err := d.notifier.Send(relayMsg); err != nil {
+			log.Printf("notification relay error: %v", err)
+		}
+	}
 	w.WriteHeader(http.StatusOK)
+}
+
+func (d *Daemon) buildRelayNotifyMessage(hookData map[string]interface{}, rawBody []byte) *notify.NotifyMessage {
+	msg := &notify.NotifyMessage{
+		Command:    string(NotifyProgress),
+		LastOutput: string(rawBody),
+	}
+	if len(hookData) == 0 {
+		return msg
+	}
+
+	if hookType, ok := hookData["tlive_hook_type"].(string); ok && strings.TrimSpace(hookType) != "" {
+		msg.Command = strings.TrimSpace(hookType)
+	}
+	if notificationType, ok := hookData["notification_type"].(string); ok {
+		msg.NotificationType = strings.TrimSpace(notificationType)
+	}
+	if sessionID, ok := hookData["tlive_session_id"].(string); ok {
+		msg.SessionID = strings.TrimSpace(sessionID)
+	}
+	if webURL, ok := hookData["web_url"].(string); ok {
+		msg.WebURL = strings.TrimSpace(webURL)
+	}
+	if toolName, ok := hookData["tool_name"].(string); ok {
+		msg.PermissionToolName = strings.TrimSpace(toolName)
+	}
+	if idleSeconds, ok := readIntField(hookData, "idle_seconds"); ok {
+		msg.IdleSeconds = idleSeconds
+	}
+	if output := pickRelayOutput(hookData); output != "" {
+		msg.LastOutput = output
+	}
+
+	if sid := msg.SessionID; sid != "" {
+		if msg.WebURL == "" {
+			msg.WebURL = d.sessionWebURL(sid)
+		}
+		if ms, found := d.mgr.GetSession(sid); found {
+			if msg.Pid == 0 {
+				msg.Pid = ms.Session.Pid
+			}
+			if msg.Duration == "" {
+				msg.Duration = ms.Session.Duration().Truncate(time.Second).String()
+			}
+			if msg.LastOutput == "" {
+				msg.LastOutput = stripANSI(string(ms.Session.LastOutput(500)))
+			}
+		}
+	}
+
+	return msg
+}
+
+func pickRelayOutput(hookData map[string]interface{}) string {
+	for _, key := range []string{"last_output", "message", "summary"} {
+		if value, ok := hookData[key].(string); ok {
+			if trimmed := strings.TrimSpace(value); trimmed != "" {
+				return trimmed
+			}
+		}
+	}
+	if text, ok := hookData["text"].(string); ok {
+		if trimmed := strings.TrimSpace(text); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func readIntField(data map[string]interface{}, key string) (int, bool) {
+	value, ok := data[key]
+	if !ok {
+		return 0, false
+	}
+	switch v := value.(type) {
+	case float64:
+		return int(v), true
+	case int:
+		return v, true
+	case int32:
+		return int(v), true
+	case int64:
+		return int(v), true
+	default:
+		return 0, false
+	}
+}
+
+func (d *Daemon) sessionWebURL(sessionID string) string {
+	if strings.TrimSpace(sessionID) == "" {
+		return ""
+	}
+	host := d.host
+	if host == "" || host == "0.0.0.0" {
+		host = "127.0.0.1"
+	}
+	return fmt.Sprintf("http://%s:%d/?token=%s&session=%s", host, d.cfg.Port, d.token, sessionID)
 }
 
 // handleHookNotifications handles GET /api/hooks/notifications — returns recent notifications for Bridge polling.

--- a/core/internal/daemon/daemon_test.go
+++ b/core/internal/daemon/daemon_test.go
@@ -2,10 +2,13 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/termlive/termlive/core/internal/notify"
 )
 
 func TestDaemon_StatusEndpoint(t *testing.T) {
@@ -172,5 +175,440 @@ func TestStripANSI(t *testing.T) {
 				t.Errorf("stripANSI(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+type stubNotifier struct {
+	err   error
+	calls int
+	last  *notify.NotifyMessage
+}
+
+func (s *stubNotifier) Send(msg *notify.NotifyMessage) error {
+	s.calls++
+	s.last = msg
+	return s.err
+}
+
+func TestDaemon_HookNotifyRelaysToNotifiers(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 4590, Token: "tok", Host: "127.0.0.1"})
+	stub := &stubNotifier{}
+	d.SetNotifiers(notify.NewMultiNotifier(stub))
+	handler := d.Handler()
+
+	req := httptest.NewRequest("POST", "/api/hooks/notify", strings.NewReader(`{"tlive_hook_type":"notification","tlive_session_id":"sess-42","notification_type":"permission_prompt","tool_name":"Bash","idle_seconds":15,"message":"hello"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("expected notifier called once, got %d", stub.calls)
+	}
+	if stub.last == nil || stub.last.Command != "notification" {
+		t.Fatalf("expected notification relay message, got %#v", stub.last)
+	}
+	if stub.last.SessionID != "sess-42" {
+		t.Fatalf("expected session id sess-42, got %#v", stub.last)
+	}
+	if stub.last.NotificationType != "permission_prompt" {
+		t.Fatalf("expected notification type permission_prompt, got %#v", stub.last)
+	}
+	if stub.last.PermissionToolName != "Bash" {
+		t.Fatalf("expected permission tool Bash, got %#v", stub.last)
+	}
+	if stub.last.IdleSeconds != 15 {
+		t.Fatalf("expected idle seconds 15, got %#v", stub.last)
+	}
+	if stub.last.LastOutput != "hello" {
+		t.Fatalf("expected extracted message output, got %q", stub.last.LastOutput)
+	}
+	if !strings.Contains(stub.last.WebURL, "session=sess-42") {
+		t.Fatalf("expected web url to include session, got %q", stub.last.WebURL)
+	}
+}
+
+func TestDaemon_HookNotifyContinuesOnRelayError(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 0, Token: "tok"})
+	stub := &stubNotifier{err: errors.New("boom")}
+	d.SetNotifiers(notify.NewMultiNotifier(stub))
+	handler := d.Handler()
+
+	req := httptest.NewRequest("POST", "/api/hooks/notify", strings.NewReader(`{"tlive_hook_type":"notification","message":"hello"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("expected notifier called once, got %d", stub.calls)
+	}
+}
+
+func TestBuildRelayNotifyMessageUsesSessionContext(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 4590, Token: "tok", Host: "0.0.0.0"})
+	ms, err := d.mgr.CreateSession("echo", []string{"hello"}, SessionConfig{Rows: 24, Cols: 80})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	ms.Session.AppendOutput([]byte("ansi-free output"))
+
+	msg := d.buildRelayNotifyMessage(map[string]interface{}{
+		"tlive_hook_type":  "stop",
+		"tlive_session_id": ms.Session.ID,
+	}, []byte(`{"tlive_hook_type":"stop"}`))
+
+	if msg.Command != "stop" {
+		t.Fatalf("expected stop command, got %q", msg.Command)
+	}
+	if msg.SessionID != ms.Session.ID {
+		t.Fatalf("expected session id %q, got %q", ms.Session.ID, msg.SessionID)
+	}
+	if msg.Pid != ms.Session.Pid {
+		t.Fatalf("expected pid %d, got %d", ms.Session.Pid, msg.Pid)
+	}
+	if msg.Duration == "" {
+		t.Fatal("expected duration to be populated")
+	}
+	if msg.LastOutput != string([]byte(`{"tlive_hook_type":"stop"}`)) {
+		t.Fatalf("expected raw body to be preserved when no hook output fields exist, got %q", msg.LastOutput)
+	}
+	if !strings.Contains(msg.WebURL, "127.0.0.1:4590") {
+		t.Fatalf("expected localhost web url, got %q", msg.WebURL)
+	}
+}
+
+func TestBuildRelayNotifyMessageUsesHookOutputWithoutSession(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 4590, Token: "tok", Host: "127.0.0.1"})
+
+	msg := d.buildRelayNotifyMessage(map[string]interface{}{
+		"tlive_hook_type":  "notification",
+		"tlive_session_id": "missing-session",
+		"message":          "hook supplied message",
+		"idle_seconds":     float64(22),
+	}, []byte(`{"tlive_hook_type":"notification"}`))
+
+	if msg.Command != "notification" {
+		t.Fatalf("expected notification command, got %q", msg.Command)
+	}
+	if msg.SessionID != "missing-session" {
+		t.Fatalf("expected session id missing-session, got %q", msg.SessionID)
+	}
+	if msg.LastOutput != "hook supplied message" {
+		t.Fatalf("expected hook output, got %q", msg.LastOutput)
+	}
+	if msg.IdleSeconds != 22 {
+		t.Fatalf("expected idle seconds 22, got %d", msg.IdleSeconds)
+	}
+	if msg.Pid != 0 {
+		t.Fatalf("expected no pid without session, got %d", msg.Pid)
+	}
+	if msg.Duration != "" {
+		t.Fatalf("expected empty duration without session, got %q", msg.Duration)
+	}
+}
+
+func TestBuildRelayNotifyMessagePreservesProvidedWebURL(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 4590, Token: "tok", Host: "127.0.0.1"})
+	ms, err := d.mgr.CreateSession("echo", []string{"hello"}, SessionConfig{Rows: 24, Cols: 80})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	msg := d.buildRelayNotifyMessage(map[string]interface{}{
+		"tlive_hook_type":  "notification",
+		"tlive_session_id": ms.Session.ID,
+		"web_url":          "https://example.test/custom",
+		"summary":          "custom summary",
+	}, []byte(`{"tlive_hook_type":"notification"}`))
+
+	if msg.WebURL != "https://example.test/custom" {
+		t.Fatalf("expected provided web URL preserved, got %q", msg.WebURL)
+	}
+	if msg.LastOutput != "custom summary" {
+		t.Fatalf("expected summary to be used as output, got %q", msg.LastOutput)
+	}
+}
+
+func TestBuildRelayNotifyMessagePrefersLastOutputOverMessageAndSummary(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 4590, Token: "tok", Host: "127.0.0.1"})
+
+	msg := d.buildRelayNotifyMessage(map[string]interface{}{
+		"last_output": "final output",
+		"message":     "message output",
+		"summary":     "summary output",
+	}, []byte(`{"tlive_hook_type":"notification"}`))
+
+	if msg.LastOutput != "final output" {
+		t.Fatalf("expected last_output to win, got %q", msg.LastOutput)
+	}
+}
+
+func TestBuildRelayNotifyMessageIgnoresUnsupportedIdleSecondsType(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 4590, Token: "tok", Host: "127.0.0.1"})
+
+	msg := d.buildRelayNotifyMessage(map[string]interface{}{
+		"idle_seconds": "22",
+	}, []byte(`{"tlive_hook_type":"notification"}`))
+
+	if msg.IdleSeconds != 0 {
+		t.Fatalf("expected unsupported idle seconds type to be ignored, got %d", msg.IdleSeconds)
+	}
+}
+
+func TestHandleHookNotify_NonJSONBodyFallsBackToRawMessage(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 0, Token: "tok"})
+	stub := &stubNotifier{}
+	d.SetNotifiers(notify.NewMultiNotifier(stub))
+	handler := d.Handler()
+
+	body := "plain text notify"
+	req := httptest.NewRequest("POST", "/api/hooks/notify", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("expected notifier called once, got %d", stub.calls)
+	}
+	if stub.last == nil {
+		t.Fatal("expected relay message")
+	}
+	if stub.last.Command != string(NotifyProgress) {
+		t.Fatalf("expected command %q, got %q", string(NotifyProgress), stub.last.Command)
+	}
+	if stub.last.LastOutput != body {
+		t.Fatalf("expected last output %q, got %q", body, stub.last.LastOutput)
+	}
+}
+
+func TestBuildRelayNotifyMessage_UsesTextFallbackOutput(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 0, Token: "tok"})
+
+	msg := d.buildRelayNotifyMessage(map[string]interface{}{
+		"tlive_hook_type": "notification",
+		"text":            "fallback text value",
+	}, []byte(`{"tlive_hook_type":"notification"}`))
+
+	if msg.LastOutput != "fallback text value" {
+		t.Fatalf("expected text fallback output, got %q", msg.LastOutput)
+	}
+}
+
+func TestSessionWebURL_UsesDefaultHostWhenEmpty(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 8080, Token: "tok", Host: ""})
+	url := d.sessionWebURL("sess-123")
+	want := "http://127.0.0.1:8080/?token=tok&session=sess-123"
+	if url != want {
+		t.Fatalf("expected %q, got %q", want, url)
+	}
+}
+
+func TestSessionWebURL_ReturnsEmptyForBlankSessionID(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 8080, Token: "tok", Host: "127.0.0.1"})
+	if url := d.sessionWebURL("   "); url != "" {
+		t.Fatalf("expected empty url for blank session id, got %q", url)
+	}
+}
+
+func TestBuildRelayNotifyMessage_TrimsMetadataFields(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 4590, Token: "tok", Host: "127.0.0.1"})
+
+	msg := d.buildRelayNotifyMessage(map[string]interface{}{
+		"tlive_hook_type":  "notification",
+		"notification_type": " permission_prompt ",
+		"tool_name":         " Bash ",
+		"web_url":           " https://example.test/custom ",
+	}, []byte(`{"tlive_hook_type":"notification"}`))
+
+	if msg.NotificationType != "permission_prompt" {
+		t.Fatalf("expected trimmed notification type, got %q", msg.NotificationType)
+	}
+	if msg.PermissionToolName != "Bash" {
+		t.Fatalf("expected trimmed tool name, got %q", msg.PermissionToolName)
+	}
+	if msg.WebURL != "https://example.test/custom" {
+		t.Fatalf("expected trimmed web url, got %q", msg.WebURL)
+	}
+}
+
+func TestReadIntFieldSupportsIntegerTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]interface{}
+		want int
+	}{
+		{name: "int", data: map[string]interface{}{"idle_seconds": int(7)}, want: 7},
+		{name: "int32", data: map[string]interface{}{"idle_seconds": int32(8)}, want: 8},
+		{name: "int64", data: map[string]interface{}{"idle_seconds": int64(9)}, want: 9},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := readIntField(tt.data, "idle_seconds")
+			if !ok {
+				t.Fatal("expected integer field to be read successfully")
+			}
+			if got != tt.want {
+				t.Fatalf("expected %d, got %d", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestReadIntFieldReturnsFalseForMissingKey(t *testing.T) {
+	if got, ok := readIntField(map[string]interface{}{}, "idle_seconds"); ok || got != 0 {
+		t.Fatalf("expected missing key to return 0, false; got %d, %v", got, ok)
+	}
+}
+
+func TestPickRelayOutputSkipsBlankValues(t *testing.T) {
+	got := pickRelayOutput(map[string]interface{}{
+		"last_output": "   ",
+		"message":     "\n\t",
+		"summary":     " summary wins ",
+		"text":        "text fallback",
+	})
+
+	if got != "summary wins" {
+		t.Fatalf("expected summary fallback after blank values, got %q", got)
+	}
+}
+
+func TestPickRelayOutputFallsBackToText(t *testing.T) {
+	got := pickRelayOutput(map[string]interface{}{
+		"last_output": "  ",
+		"message":     "\t",
+		"summary":     "\n",
+		"text":        " text fallback ",
+	})
+
+	if got != "text fallback" {
+		t.Fatalf("expected text fallback, got %q", got)
+	}
+}
+
+func TestHandleHookNotify_StopWithoutSessionPreservesRawBody(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 0, Token: "tok"})
+	stub := &stubNotifier{}
+	d.SetNotifiers(notify.NewMultiNotifier(stub))
+	handler := d.Handler()
+
+	body := `{"tlive_hook_type":"stop","tlive_session_id":"missing-session"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/hooks/notify", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("expected notifier called once, got %d", stub.calls)
+	}
+	if stub.last == nil {
+		t.Fatal("expected relay message")
+	}
+	if stub.last.Command != "stop" {
+		t.Fatalf("expected stop command, got %q", stub.last.Command)
+	}
+	if stub.last.LastOutput != body {
+		t.Fatalf("expected raw body preserved, got %q", stub.last.LastOutput)
+	}
+}
+
+func TestHandleHookNotify_StopWithSessionEnrichesLastOutput(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 4590, Token: "tok", Host: "127.0.0.1"})
+	stub := &stubNotifier{}
+	d.SetNotifiers(notify.NewMultiNotifier(stub))
+	handler := d.Handler()
+
+	ms, err := d.mgr.CreateSession("echo", []string{"hello"}, SessionConfig{Rows: 24, Cols: 80})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	ms.Session.AppendOutput([]byte("session-enriched output"))
+
+	body := `{"tlive_hook_type":"stop","tlive_session_id":"` + ms.Session.ID + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/hooks/notify", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if stub.calls != 1 {
+		t.Fatalf("expected notifier called once, got %d", stub.calls)
+	}
+	if stub.last == nil {
+		t.Fatal("expected relay message")
+	}
+	if stub.last.Command != "stop" {
+		t.Fatalf("expected stop command, got %q", stub.last.Command)
+	}
+	if stub.last.LastOutput != "session-enriched output" {
+		t.Fatalf("expected enriched last output, got %q", stub.last.LastOutput)
+	}
+}
+
+func TestHandleHookNotifySucceedsWithoutNotifier(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 0, Token: "tok"})
+	handler := d.Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/hooks/notify", strings.NewReader(`{"tlive_hook_type":"notification"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHandleHookNotifyRejectsNonPOST(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 0, Token: "tok"})
+	stub := &stubNotifier{}
+	d.SetNotifiers(notify.NewMultiNotifier(stub))
+	handler := d.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/hooks/notify", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+	if stub.calls != 0 {
+		t.Fatalf("expected notifier not called, got %d", stub.calls)
+	}
+}
+
+func TestBuildRelayNotifyMessage_TrimsHookType(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 0, Token: "tok"})
+
+	msg := d.buildRelayNotifyMessage(map[string]interface{}{
+		"tlive_hook_type": " stop ",
+	}, []byte(`{"tlive_hook_type":"notification"}`))
+
+	if msg.Command != "stop" {
+		t.Fatalf("expected trimmed hook type stop, got %q", msg.Command)
+	}
+}
+
+func TestSessionWebURL_UsesLoopbackForWildcardHost(t *testing.T) {
+	d := NewDaemon(DaemonConfig{Port: 8080, Token: "tok", Host: "0.0.0.0"})
+	url := d.sessionWebURL("sess-123")
+	want := "http://127.0.0.1:8080/?token=tok&session=sess-123"
+	if url != want {
+		t.Fatalf("expected %q, got %q", want, url)
 	}
 }

--- a/core/internal/notify/notifier.go
+++ b/core/internal/notify/notifier.go
@@ -1,0 +1,693 @@
+package notify
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+type NotifyMessage struct {
+	SessionID          string
+	Command            string
+	Pid                int
+	Duration           string
+	LastOutput         string
+	WebURL             string
+	IdleSeconds        int
+	NotificationType   string
+	PermissionToolName string
+}
+
+type Notifier interface {
+	Send(msg *NotifyMessage) error
+}
+
+type MultiNotifier struct {
+	notifiers []Notifier
+}
+
+func NewMultiNotifier(notifiers ...Notifier) *MultiNotifier {
+	filtered := make([]Notifier, 0, len(notifiers))
+	for _, notifier := range notifiers {
+		if notifier != nil {
+			filtered = append(filtered, notifier)
+		}
+	}
+	return &MultiNotifier{notifiers: filtered}
+}
+
+func (m *MultiNotifier) Send(msg *NotifyMessage) error {
+	if m == nil {
+		return nil
+	}
+	var firstErr error
+	for _, notifier := range m.notifiers {
+		if err := notifier.Send(msg); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (m *MultiNotifier) Len() int {
+	if m == nil {
+		return 0
+	}
+	return len(m.notifiers)
+}
+
+const defaultWeChatHTTPTimeout = 8 * time.Second
+
+type WeChatNotifier struct {
+	webhookURL string
+	client     *http.Client
+}
+
+func NewWeChatNotifier(webhookURL string) *WeChatNotifier {
+	trimmed := strings.TrimSpace(webhookURL)
+	if trimmed == "" {
+		return nil
+	}
+	return &WeChatNotifier{
+		webhookURL: trimmed,
+		client:     &http.Client{Timeout: defaultWeChatHTTPTimeout},
+	}
+}
+
+func (w *WeChatNotifier) Send(msg *NotifyMessage) error {
+	if w == nil || w.webhookURL == "" {
+		return nil
+	}
+	client := w.client
+	if client == nil {
+		client = &http.Client{Timeout: defaultWeChatHTTPTimeout}
+	}
+	content := renderWeChatContent(msg)
+	payload := map[string]any{
+		"msgtype":  "markdown",
+		"markdown": map[string]string{"content": content},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Post(w.webhookURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("wechat webhook returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func renderWeChatContent(msg *NotifyMessage) string {
+	if msg == nil {
+		return "**TLive 通知**"
+	}
+
+	command := strings.TrimSpace(msg.Command)
+	if command == "" {
+		command = "notification"
+	}
+	messageType := strings.TrimSpace(msg.NotificationType)
+	category := classifyWeChatNotification(command, messageType)
+
+	sections := []string{fmt.Sprintf("**%s**", weChatNotificationTitle(category, msg.PermissionToolName))}
+
+	meta := make([]string, 0, 6)
+	meta = append(meta, fmt.Sprintf("> 類型：`%s`", command))
+	if messageType != "" {
+		meta = append(meta, fmt.Sprintf("> 子類型：`%s`", messageType))
+	}
+	if tool := strings.TrimSpace(msg.PermissionToolName); tool != "" {
+		meta = append(meta, fmt.Sprintf("> 工具：`%s`", tool))
+	}
+	if sessionID := strings.TrimSpace(msg.SessionID); sessionID != "" {
+		meta = append(meta, fmt.Sprintf("> 會話：`%s`", sessionID))
+	}
+	if pid := msg.Pid; pid > 0 {
+		meta = append(meta, fmt.Sprintf("> PID：`%d`", pid))
+	}
+	if duration := strings.TrimSpace(msg.Duration); duration != "" {
+		meta = append(meta, fmt.Sprintf("> 持續時間：%s", duration))
+	}
+	if idle := msg.IdleSeconds; idle > 0 {
+		meta = append(meta, fmt.Sprintf("> 空閒：%ds", idle))
+	}
+	sections = append(sections, strings.Join(meta, "\n"))
+
+	if summary := strings.TrimSpace(weChatSummaryLine(category, msg.PermissionToolName)); summary != "" {
+		sections = append(sections, summary)
+	}
+	if hint := strings.TrimSpace(weChatActionHint(category)); hint != "" {
+		sections = append(sections, hint)
+	}
+	if output := weChatOutputExcerpt(msg.LastOutput, category); output != "" {
+		sections = append(sections, fmt.Sprintf("%s\n```\n%s\n```", weChatOutputLabel(category), output))
+	}
+	if webURL := strings.TrimSpace(msg.WebURL); webURL != "" {
+		sections = append(sections, fmt.Sprintf("[打開終端](%s)", webURL))
+	}
+
+	return strings.Join(sections, "\n\n")
+}
+
+func weChatNotificationTitle(category, toolName string) string {
+	switch category {
+	case "stop":
+		return "TLive 停止通知"
+	case "permission_prompt":
+		if tool := strings.TrimSpace(toolName); tool != "" {
+			return fmt.Sprintf("TLive 權限確認 · %s", tool)
+		}
+		return "TLive 權限確認"
+	case "idle_prompt":
+		return "TLive 等待輸入"
+	case "error":
+		return "TLive 異常通知"
+	case "completion":
+		return "TLive 任務完成"
+	default:
+		return "TLive 進度通知"
+	}
+}
+
+func weChatSummaryLine(category, toolName string) string {
+	switch category {
+	case "permission_prompt":
+		if tool := strings.TrimSpace(toolName); tool != "" {
+			return fmt.Sprintf("需要你確認工具權限後才能繼續：`%s`", tool)
+		}
+		return "需要你確認工具權限後才能繼續。"
+	case "idle_prompt":
+		return "目前執行流程暫停中，正在等待你的下一步輸入。"
+	case "completion":
+		return "本次執行已完成，重點結果與最後輸出如下。"
+	case "error":
+		return "執行過程出現異常，以下是最近一次可用輸出。"
+	case "stop":
+		return "本次執行已停止，以下是結束前保留下來的內容。"
+	default:
+		return "執行中有新的進度更新。"
+	}
+}
+
+func weChatActionHint(category string) string {
+	switch category {
+	case "permission_prompt":
+		return "請先完成權限確認，再繼續後續流程。"
+	case "idle_prompt":
+		return "如需繼續，請回到終端或 Web 端輸入下一個指令。"
+	case "completion":
+		return "若結果符合預期，可直接進入下一步；若不符，建議先回看輸出細節。"
+	case "error":
+		return "建議優先查看錯誤上下文，再決定是否重試或調整指令。"
+	case "stop":
+		return "如需恢復處理，可重新進入該會話或重新執行命令。"
+	default:
+		return "可打開終端查看完整上下文與最新狀態。"
+	}
+}
+
+func weChatOutputLabel(category string) string {
+	switch category {
+	case "completion":
+		return "結果摘錄："
+	case "error":
+		return "錯誤上下文："
+	case "permission_prompt":
+		return "待確認內容："
+	case "idle_prompt":
+		return "目前停留內容："
+	case "stop":
+		return "停止前輸出："
+	default:
+		return "最近輸出："
+	}
+}
+
+func classifyWeChatNotification(command, notificationType string) string {
+	command = strings.ToLower(strings.TrimSpace(command))
+	notificationType = strings.ToLower(strings.TrimSpace(notificationType))
+
+	if command == "stop" {
+		return "stop"
+	}
+	if notificationType != "" {
+		switch notificationType {
+		case "permission_prompt":
+			return "permission_prompt"
+		case "idle_prompt":
+			return "idle_prompt"
+		case "error", "failed", "failure":
+			return "error"
+		case "complete", "completed", "completion", "finished":
+			return "completion"
+		}
+		if strings.Contains(notificationType, "idle") || strings.Contains(notificationType, "waiting") {
+			return "idle_prompt"
+		}
+		if strings.Contains(notificationType, "error") || strings.Contains(notificationType, "fail") {
+			return "error"
+		}
+		if strings.Contains(notificationType, "complete") || strings.Contains(notificationType, "finish") || strings.Contains(notificationType, "done") {
+			return "completion"
+		}
+	}
+	return "progress"
+}
+
+func weChatOutputExcerpt(lastOutput, category string) string {
+	normalized := normalizeWeChatOutput(lastOutput)
+	if normalized == "" {
+		return ""
+	}
+
+	switch category {
+	case "completion":
+		if summary := completionSummaryLine(normalized); summary != "" {
+			return sanitizeWeChatCodeBlock(summary)
+		}
+		return sanitizeWeChatCodeBlock(firstNonEmptyLine(normalized))
+	case "progress":
+		lines := dedupeAdjacentLines(strings.Split(normalized, "\n"))
+		filtered := filterProgressLines(lines)
+		if len(filtered) > 0 {
+			return sanitizeWeChatCodeBlock(filtered[len(filtered)-1])
+		}
+		if len(lines) > 0 {
+			return sanitizeWeChatCodeBlock(lines[len(lines)-1])
+		}
+		if tail := lastNonEmptyLine(normalized); tail != "" {
+			return sanitizeWeChatCodeBlock(tail)
+		}
+		return sanitizeWeChatCodeBlock(normalized)
+	case "error":
+		if excerpt := errorFocusedExcerpt(normalized); excerpt != "" {
+			return sanitizeWeChatCodeBlock(excerpt)
+		}
+		return sanitizeWeChatCodeBlock(lastLines(normalized, 12))
+	case "permission_prompt", "idle_prompt", "stop":
+		return sanitizeWeChatCodeBlock(lastLines(normalized, 8))
+	default:
+		return sanitizeWeChatCodeBlock(normalized)
+	}
+}
+
+func completionSummaryLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		if strings.HasPrefix(lower, "summary:") || strings.HasPrefix(lower, "result:") || strings.HasPrefix(lower, "done:") || strings.HasPrefix(lower, "completed:") || strings.HasPrefix(lower, "完成：") || strings.HasPrefix(lower, "結果：") {
+			return trimmed
+		}
+	}
+	if success := completionSuccessLine(lines); success != "" {
+		return success
+	}
+	if informative := bestInformativeLine(lines); informative != "" {
+		return informative
+	}
+	return firstNonEmptyLine(s)
+}
+
+func completionSuccessLine(lines []string) string {
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		if strings.Contains(lower, "succeeded") || strings.Contains(lower, "success") || strings.Contains(lower, "completed") || strings.Contains(lower, "complete") || strings.Contains(lower, "done") || strings.Contains(lower, "finished") || strings.Contains(lower, "成功") || strings.Contains(lower, "完成") || strings.Contains(lower, "已完成") {
+			if !looksLikeCompletionNoise(lower) {
+				return trimmed
+			}
+		}
+	}
+	return ""
+}
+
+func looksLikeCompletionNoise(lower string) bool {
+	return strings.Contains(lower, "starting") || strings.Contains(lower, "running") || strings.Contains(lower, "loading")
+}
+
+func bestInformativeLine(lines []string) string {
+	for i := len(lines) - 1; i >= 0; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" {
+			continue
+		}
+		if !looksLikeInformativeNoise(strings.ToLower(trimmed)) {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func looksLikeInformativeNoise(lower string) bool {
+	if lower == "" {
+		return true
+	}
+	return strings.Contains(lower, "starting") || strings.Contains(lower, "running") || strings.Contains(lower, "loading") || strings.Contains(lower, "booting")
+}
+
+func errorFocusedExcerpt(s string) string {
+	lines := strings.Split(s, "\n")
+	idx, level := findLastErrorAnchor(lines)
+	if idx < 0 {
+		return lastLines(s, 12)
+	}
+
+	switch level {
+	case 1:
+		lower := strings.ToLower(strings.TrimSpace(lines[idx]))
+		switch {
+		case strings.Contains(lower, "traceback"):
+			if excerpt := tracebackWindow(lines, idx); excerpt != "" {
+				return excerpt
+			}
+		case strings.Contains(lower, "caused by"):
+			if excerpt := causedByWindow(lines, idx); excerpt != "" {
+				return excerpt
+			}
+		}
+		return genericErrorWindow(lines, idx, 2, 4)
+	case 2:
+		return genericErrorWindow(lines, idx, 2, 3)
+	default:
+		return genericErrorWindow(lines, idx, 1, 2)
+	}
+}
+
+func findLastErrorAnchor(lines []string) (int, int) {
+	bestIdx, bestLevel := -1, 0
+	for i := len(lines) - 1; i >= 0; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		level := errorAnchorLevel(lower)
+		if level == 0 {
+			continue
+		}
+		if level == 1 {
+			if strings.Contains(lower, "traceback") {
+				return i, level
+			}
+			if bestIdx == -1 {
+				bestIdx, bestLevel = i, level
+			}
+			continue
+		}
+		if bestIdx == -1 {
+			bestIdx, bestLevel = i, level
+		}
+	}
+	return bestIdx, bestLevel
+}
+
+func errorAnchorLevel(lower string) int {
+	switch {
+	case strings.Contains(lower, "panic:"), strings.HasPrefix(lower, "error:"), strings.Contains(lower, "traceback"), strings.Contains(lower, "caused by:"), strings.Contains(lower, "fatal"):
+		return 1
+	case strings.Contains(lower, "failed"), strings.Contains(lower, "exception"):
+		return 2
+	case strings.HasPrefix(lower, "at "):
+		return 3
+	default:
+		return 0
+	}
+}
+
+func tracebackWindow(lines []string, idx int) string {
+	start := idx
+	for start > 0 {
+		prev := strings.TrimSpace(lines[start-1])
+		lowerPrev := strings.ToLower(prev)
+		if prev == "" || strings.Contains(lowerPrev, "caused by:") {
+			start--
+			continue
+		}
+		break
+	}
+	end := idx + 1
+	for end < len(lines) {
+		trimmed := strings.TrimSpace(lines[end])
+		if trimmed == "" {
+			break
+		}
+		end++
+		if strings.HasPrefix(strings.ToLower(trimmed), "error:") || strings.Contains(strings.ToLower(trimmed), "panic:") {
+			break
+		}
+	}
+	return joinNonEmptyLines(skipLeadingAtLine(lines[start:end]))
+}
+
+func skipLeadingAtLine(lines []string) []string {
+	if len(lines) == 0 {
+		return lines
+	}
+	first := strings.TrimSpace(lines[0])
+	if strings.HasPrefix(strings.ToLower(first), "at ") {
+		return lines[1:]
+	}
+	return lines
+}
+
+func causedByWindow(lines []string, idx int) string {
+	start := idx
+	for start > 0 {
+		prev := strings.TrimSpace(lines[start-1])
+		if strings.Contains(strings.ToLower(prev), "caused by:") {
+			start--
+			continue
+		}
+		break
+	}
+	end := idx + 1
+	for end < len(lines) {
+		trimmed := strings.TrimSpace(lines[end])
+		lower := strings.ToLower(trimmed)
+		if trimmed == "" {
+			break
+		}
+		if end > idx && !(strings.HasPrefix(lower, "at ") || strings.Contains(lower, "traceback") || strings.HasPrefix(lower, "error:") || strings.Contains(lower, "caused by:")) {
+			break
+		}
+		end++
+	}
+	return joinNonEmptyLines(lines[start:end])
+}
+
+func genericErrorWindow(lines []string, idx int, before, after int) string {
+	start := idx - before
+	if start < 0 {
+		start = 0
+	}
+	end := idx + after + 1
+	if end > len(lines) {
+		end = len(lines)
+	}
+	return joinNonEmptyLines(lines[start:end])
+}
+
+func joinNonEmptyLines(lines []string) string {
+	filtered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			filtered = append(filtered, trimmed)
+		}
+	}
+	return strings.Join(filtered, "\n")
+}
+
+func filterProgressLines(lines []string) []string {
+	filtered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || looksLikeProgressNoise(trimmed) {
+			continue
+		}
+		filtered = append(filtered, trimmed)
+	}
+	return filtered
+}
+
+func looksLikeProgressNoise(line string) bool {
+	lower := strings.ToLower(strings.TrimSpace(line))
+	if lower == "" {
+		return true
+	}
+	if isPureSymbolLine(lower) || isSpinnerLine(lower) || isProgressBarLine(lower) || isTimingHeartbeatLine(lower) {
+		return true
+	}
+	return false
+}
+
+func isPureSymbolLine(line string) bool {
+	for _, r := range line {
+		if !strings.ContainsRune(".-_=~>#[]()|/\\*+:", r) && (r < '0' || r > '9') && r != ' ' && r != '%' {
+			return false
+		}
+	}
+	return true
+}
+
+func isSpinnerLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return trimmed == "|" || trimmed == "/" || trimmed == "-" || trimmed == "\\"
+}
+
+func isProgressBarLine(line string) bool {
+	hasPercent := strings.Contains(line, "%")
+	hasBarChars := strings.ContainsAny(line, "[]=#")
+	if !hasPercent && !hasBarChars {
+		return false
+	}
+	letters := 0
+	for _, r := range line {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			letters++
+		}
+	}
+	if letters > 6 {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(line))
+	if strings.Contains(lower, "step") || strings.Contains(lower, "checkpoint") || strings.Contains(lower, "download") || strings.Contains(lower, "upload") {
+		return false
+	}
+	return true
+}
+
+func isTimingHeartbeatLine(line string) bool {
+	if strings.HasPrefix(line, "elapsed:") || strings.HasPrefix(line, "time:") {
+		return true
+	}
+	return strings.HasPrefix(line, "running for ")
+}
+
+func dedupeAdjacentLines(lines []string) []string {
+	if len(lines) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(lines))
+	var last string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if trimmed == last {
+			continue
+		}
+		result = append(result, trimmed)
+		last = trimmed
+	}
+	return result
+}
+
+func normalizeWeChatOutput(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return ""
+	}
+	trimmed = strings.ReplaceAll(trimmed, "\r\n", "\n")
+	trimmed = strings.ReplaceAll(trimmed, "\r", "\n")
+	return trimmed
+}
+
+func firstNonEmptyLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if trimmed := strings.TrimSpace(lines[i]); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func lastLines(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	filtered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if trimmed := strings.TrimRight(line, " \t"); trimmed != "" {
+			filtered = append(filtered, trimmed)
+		}
+	}
+	if len(filtered) == 0 {
+		return ""
+	}
+	if len(filtered) > n {
+		filtered = filtered[len(filtered)-n:]
+	}
+	return strings.Join(filtered, "\n")
+}
+
+func truncateRunes(s string, limit int) string {
+	if limit <= 0 || s == "" {
+		return ""
+	}
+	if utf8.RuneCountInString(s) <= limit {
+		return s
+	}
+	count := 0
+	for idx := range s {
+		if count == limit {
+			return s[:idx]
+		}
+		count++
+	}
+	return s
+}
+
+func sanitizeWeChatCodeBlock(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return ""
+	}
+	trimmed = strings.ReplaceAll(trimmed, "```", "'''")
+	trimmed = strings.ReplaceAll(trimmed, "\r\n", "\n")
+	trimmed = strings.ReplaceAll(trimmed, "\r", "\n")
+	const maxLen = 1200
+	if utf8.RuneCountInString(trimmed) > maxLen {
+		if lastFence := strings.LastIndex(trimmed, "'''"); lastFence >= 0 {
+			prefixLimit := maxLen - utf8.RuneCountInString("\n…")
+			if prefixLimit < 0 {
+				prefixLimit = 0
+			}
+			fencePrefix := trimmed[:lastFence]
+			if fenceRunes := utf8.RuneCountInString(fencePrefix); fenceRunes < prefixLimit {
+				prefixLimit = fenceRunes
+			}
+			trimmed = strings.TrimSpace(truncateRunes(trimmed, prefixLimit)+trimmed[lastFence:]) + "\n…"
+		} else {
+			trimmed = strings.TrimSpace(truncateRunes(trimmed, maxLen)) + "\n…"
+		}
+	}
+	return trimmed
+}

--- a/core/internal/notify/notifier_test.go
+++ b/core/internal/notify/notifier_test.go
@@ -1,0 +1,518 @@
+package notify
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestNewWeChatNotifierTrimsAndSetsTimeout(t *testing.T) {
+	notifier := NewWeChatNotifier("  https://example.test/wechat  ")
+	if notifier == nil {
+		t.Fatal("expected notifier")
+	}
+	if notifier.webhookURL != "https://example.test/wechat" {
+		t.Fatalf("expected trimmed webhook URL, got %q", notifier.webhookURL)
+	}
+	if notifier.client == nil {
+		t.Fatal("expected HTTP client")
+	}
+	if notifier.client.Timeout != defaultWeChatHTTPTimeout {
+		t.Fatalf("expected timeout %s, got %s", defaultWeChatHTTPTimeout, notifier.client.Timeout)
+	}
+}
+
+func TestNewWeChatNotifierReturnsNilForEmptyURL(t *testing.T) {
+	if notifier := NewWeChatNotifier("   "); notifier != nil {
+		t.Fatalf("expected nil notifier for empty URL, got %#v", notifier)
+	}
+}
+
+func TestWeChatNotifierSendPostsMarkdownPayload(t *testing.T) {
+	var captured struct {
+		MsgType  string `json:"msgtype"`
+		Markdown struct {
+			Content string `json:"content"`
+		} `json:"markdown"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if got := r.Header.Get("Content-Type"); !strings.Contains(got, "application/json") {
+			t.Fatalf("expected application/json content type, got %q", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier := &WeChatNotifier{
+		webhookURL: server.URL,
+		client:     server.Client(),
+	}
+
+	msg := &NotifyMessage{Command: "notification", NotificationType: "permission_prompt", PermissionToolName: "Bash", LastOutput: "approve me"}
+	if err := notifier.Send(msg); err != nil {
+		t.Fatalf("expected send to succeed, got %v", err)
+	}
+	if captured.MsgType != "markdown" {
+		t.Fatalf("expected markdown msgtype, got %q", captured.MsgType)
+	}
+	if !strings.Contains(captured.Markdown.Content, "TLive 權限確認") {
+		t.Fatalf("expected rendered markdown content, got %q", captured.Markdown.Content)
+	}
+	if !strings.Contains(captured.Markdown.Content, "approve me") {
+		t.Fatalf("expected output excerpt in markdown content, got %q", captured.Markdown.Content)
+	}
+}
+
+func TestWeChatNotifierSendReturnsErrorOnNonOKStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	notifier := &WeChatNotifier{
+		webhookURL: server.URL,
+		client:     server.Client(),
+	}
+
+	err := notifier.Send(&NotifyMessage{Command: "progress", LastOutput: "hello"})
+	if err == nil || !strings.Contains(err.Error(), "status 502") {
+		t.Fatalf("expected 502 error, got %v", err)
+	}
+}
+
+func TestWeChatNotifierSendFallsBackToDefaultClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier := &WeChatNotifier{webhookURL: server.URL}
+	if err := notifier.Send(&NotifyMessage{Command: "progress", LastOutput: "hello"}); err != nil {
+		t.Fatalf("expected nil-client fallback to succeed, got %v", err)
+	}
+}
+
+func TestWeChatNotifierSendReturnsTransportError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	client := server.Client()
+	server.Close()
+
+	notifier := &WeChatNotifier{
+		webhookURL: server.URL,
+		client:     client,
+	}
+
+	err := notifier.Send(&NotifyMessage{Command: "progress", LastOutput: "hello"})
+	if err == nil {
+		t.Fatal("expected transport error")
+	}
+}
+
+func TestWeChatNotifierSendReturnsNilForNilReceiverOrEmptyURL(t *testing.T) {
+	var notifier *WeChatNotifier
+	if err := notifier.Send(&NotifyMessage{Command: "progress"}); err != nil {
+		t.Fatalf("expected nil receiver to no-op, got %v", err)
+	}
+
+	notifier = &WeChatNotifier{}
+	if err := notifier.Send(&NotifyMessage{Command: "progress"}); err != nil {
+		t.Fatalf("expected empty webhook URL to no-op, got %v", err)
+	}
+}
+
+type fakeNotifier struct {
+	calls int
+	err   error
+}
+
+func (f *fakeNotifier) Send(_ *NotifyMessage) error {
+	f.calls++
+	return f.err
+}
+
+func TestNewMultiNotifierFiltersNil(t *testing.T) {
+	one := &fakeNotifier{}
+	multi := NewMultiNotifier(nil, one)
+	if multi.Len() != 1 {
+		t.Fatalf("expected 1 notifier, got %d", multi.Len())
+	}
+}
+
+func TestMultiNotifierSendReturnsFirstError(t *testing.T) {
+	first := &fakeNotifier{err: assertErr("boom")}
+	second := &fakeNotifier{}
+	multi := NewMultiNotifier(first, second)
+
+	err := multi.Send(&NotifyMessage{Command: "progress", LastOutput: "hello"})
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("expected first error boom, got %v", err)
+	}
+	if first.calls != 1 || second.calls != 1 {
+		t.Fatalf("expected both notifiers called once, got %d and %d", first.calls, second.calls)
+	}
+}
+
+func TestMultiNotifierSendReturnsNilOnNilReceiver(t *testing.T) {
+	var multi *MultiNotifier
+	if err := multi.Send(&NotifyMessage{Command: "progress"}); err != nil {
+		t.Fatalf("expected nil error for nil multi notifier, got %v", err)
+	}
+}
+
+func TestRenderWeChatContentIncludesStructuredMetadata(t *testing.T) {
+	content := renderWeChatContent(&NotifyMessage{
+		SessionID:        "sess-123",
+		Command:          "stop",
+		NotificationType: "finished",
+		Pid:              4321,
+		Duration:         "2m10s",
+		LastOutput:       "line one\nline two",
+		WebURL:           "https://example.test/terminal",
+		IdleSeconds:      15,
+	})
+
+	checks := []string{
+		"**TLive 停止通知**",
+		"> 類型：`stop`",
+		"> 子類型：`finished`",
+		"> 會話：`sess-123`",
+		"> PID：`4321`",
+		"> 持續時間：2m10s",
+		"> 空閒：15s",
+		"本次執行已停止，以下是結束前保留下來的內容。",
+		"如需恢復處理，可重新進入該會話或重新執行命令。",
+		"[打開終端](https://example.test/terminal)",
+	}
+	assertContainsAll(t, content, checks)
+}
+
+func TestRenderWeChatContentClassifiesPermissionPrompt(t *testing.T) {
+	content := renderWeChatContent(&NotifyMessage{
+		Command:            "notification",
+		NotificationType:   "permission_prompt",
+		PermissionToolName: "Bash",
+		LastOutput:         "command wants approval",
+	})
+
+	checks := []string{
+		"**TLive 權限確認 · Bash**",
+		"> 子類型：`permission_prompt`",
+		"> 工具：`Bash`",
+		"需要你確認工具權限後才能繼續：`Bash`",
+		"請先完成權限確認，再繼續後續流程。",
+	}
+	assertContainsAll(t, content, checks)
+}
+
+func TestRenderWeChatContentSelectionRules(t *testing.T) {
+	cases := []struct {
+		name       string
+		msg        *NotifyMessage
+		title      string
+		label      string
+		summary    string
+		actionHint string
+		wants      []string
+		notWants   []string
+	}{
+		{
+			name: "completion_prefers_summary_prefix",
+			msg: &NotifyMessage{
+				Command:          "notification",
+				NotificationType: "completed",
+				LastOutput:       "noise line\nSummary: build succeeded\nfinal detail",
+			},
+			title:      "**TLive 任務完成**",
+			label:      "結果摘錄：",
+			summary:    "本次執行已完成，重點結果與最後輸出如下。",
+			actionHint: "若結果符合預期，可直接進入下一步；若不符，建議先回看輸出細節。",
+			wants: []string{
+				"Summary: build succeeded",
+			},
+			notWants: []string{"noise line"},
+		},
+		{
+			name: "completion_falls_back_to_success_line",
+			msg: &NotifyMessage{
+				Command:          "notification",
+				NotificationType: "completed",
+				LastOutput:       "booting\nchecking cache\nBuild completed successfully\nartifact: dist/app",
+			},
+			title:      "**TLive 任務完成**",
+			label:      "結果摘錄：",
+			summary:    "本次執行已完成，重點結果與最後輸出如下。",
+			actionHint: "若結果符合預期，可直接進入下一步；若不符，建議先回看輸出細節。",
+			wants: []string{
+				"Build completed successfully",
+			},
+			notWants: []string{"booting"},
+		},
+		{
+			name: "completion_falls_back_to_informative_tail",
+			msg: &NotifyMessage{
+				Command:          "notification",
+				NotificationType: "completed",
+				LastOutput:       "booting\nloading modules\nartifact path: dist/app.tar.gz",
+			},
+			title:      "**TLive 任務完成**",
+			label:      "結果摘錄：",
+			summary:    "本次執行已完成，重點結果與最後輸出如下。",
+			actionHint: "若結果符合預期，可直接進入下一步；若不符，建議先回看輸出細節。",
+			wants: []string{
+				"artifact path: dist/app.tar.gz",
+			},
+			notWants: []string{"booting"},
+		},
+		{
+			name: "error_prefers_traceback_context",
+			msg: &NotifyMessage{
+				Command:          "notification",
+				NotificationType: "error",
+				LastOutput:       strings.Join([]string{"bootstrap", "setup", "at bootstrap", "Caused by: upstream timeout", "Traceback (most recent call last):", "frame 1", "frame 2", "Error: boom", "cleanup"}, "\n"),
+			},
+			title:      "**TLive 異常通知**",
+			label:      "錯誤上下文：",
+			summary:    "執行過程出現異常，以下是最近一次可用輸出。",
+			actionHint: "建議優先查看錯誤上下文，再決定是否重試或調整指令。",
+			wants: []string{
+				"Caused by: upstream timeout",
+				"Traceback (most recent call last):",
+				"Error: boom",
+			},
+			notWants: []string{"bootstrap"},
+		},
+		{
+			name: "error_preserves_caused_by_chain",
+			msg: &NotifyMessage{
+				Command:          "notification",
+				NotificationType: "error",
+				LastOutput:       strings.Join([]string{"warmup", "Caused by: upstream timeout", "at retryLoop", "Error: request aborted", "cleanup"}, "\n"),
+			},
+			title:      "**TLive 異常通知**",
+			label:      "錯誤上下文：",
+			summary:    "執行過程出現異常，以下是最近一次可用輸出。",
+			actionHint: "建議優先查看錯誤上下文，再決定是否重試或調整指令。",
+			wants: []string{
+				"Caused by: upstream timeout",
+				"Error: request aborted",
+			},
+			notWants: []string{"warmup"},
+		},
+		{
+			name: "progress_prefers_latest_semantic_line",
+			msg: &NotifyMessage{
+				Command:    "progress",
+				LastOutput: "step 1\nstep 1\nstep 2\nstep 2\nlatest checkpoint",
+			},
+			title:      "**TLive 進度通知**",
+			label:      "最近輸出：",
+			summary:    "執行中有新的進度更新。",
+			actionHint: "可打開終端查看完整上下文與最新狀態。",
+			wants: []string{
+				"latest checkpoint",
+			},
+			notWants: []string{"step 1", "step 2"},
+		},
+		{
+			name: "progress_drops_bar_and_timing_noise",
+			msg: &NotifyMessage{
+				Command:    "progress",
+				LastOutput: "step 1\n[####----] 40%\nelapsed: 12s\nlatest checkpoint",
+			},
+			title:      "**TLive 進度通知**",
+			label:      "最近輸出：",
+			summary:    "執行中有新的進度更新。",
+			actionHint: "可打開終端查看完整上下文與最新狀態。",
+			wants: []string{
+				"latest checkpoint",
+			},
+			notWants: []string{"[####----] 40%", "elapsed: 12s"},
+		},
+		{
+			name: "progress_prefers_latest_semantic_line_over_percent_line",
+			msg: &NotifyMessage{
+				Command:    "progress",
+				LastOutput: "[42%] download checkpoint ready\nnext step pending",
+			},
+			title:      "**TLive 進度通知**",
+			label:      "最近輸出：",
+			summary:    "執行中有新的進度更新。",
+			actionHint: "可打開終端查看完整上下文與最新狀態。",
+			wants: []string{
+				"next step pending",
+			},
+			notWants: []string{"[42%] download checkpoint ready"},
+		},
+		{
+			name: "progress_keeps_descriptive_percent_when_it_is_only_signal",
+			msg: &NotifyMessage{
+				Command:    "progress",
+				LastOutput: "[42%] download checkpoint ready",
+			},
+			title:      "**TLive 進度通知**",
+			label:      "最近輸出：",
+			summary:    "執行中有新的進度更新。",
+			actionHint: "可打開終端查看完整上下文與最新狀態。",
+			wants: []string{
+				"[42%] download checkpoint ready",
+			},
+		},
+		{
+			name: "progress_falls_back_to_last_non_empty_noise_line",
+			msg: &NotifyMessage{
+				Command:    "progress",
+				LastOutput: "|\n/\n-\n\\",
+			},
+			title:      "**TLive 進度通知**",
+			label:      "最近輸出：",
+			summary:    "執行中有新的進度更新。",
+			actionHint: "可打開終端查看完整上下文與最新狀態。",
+			wants: []string{
+				"\\",
+			},
+		},
+		{
+			name: "permission_prompt_keeps_pending_excerpt",
+			msg: &NotifyMessage{
+				Command:            "notification",
+				NotificationType:   "permission_prompt",
+				PermissionToolName: "Bash",
+				LastOutput:         "command wants approval",
+			},
+			title:      "**TLive 權限確認 · Bash**",
+			label:      "待確認內容：",
+			summary:    "需要你確認工具權限後才能繼續：`Bash`",
+			actionHint: "請先完成權限確認，再繼續後續流程。",
+			wants: []string{
+				"command wants approval",
+			},
+		},
+		{
+			name: "idle_keeps_recent_tail_excerpt",
+			msg: &NotifyMessage{
+				Command:          "notification",
+				NotificationType: "idle_prompt",
+				LastOutput:       strings.Join([]string{"line1", "line2", "line3", "line4", "line5", "line6", "line7", "line8", "line9"}, "\n"),
+			},
+			title:      "**TLive 等待輸入**",
+			label:      "目前停留內容：",
+			summary:    "目前執行流程暫停中，正在等待你的下一步輸入。",
+			actionHint: "如需繼續，請回到終端或 Web 端輸入下一個指令。",
+			wants: []string{
+				"line9",
+			},
+			notWants: []string{"line1"},
+		},
+		{
+			name: "stop_keeps_recent_tail_excerpt",
+			msg: &NotifyMessage{
+				Command:          "stop",
+				NotificationType: "finished",
+				LastOutput:       strings.Join([]string{"line1", "line2", "line3", "line4", "line5", "line6", "line7", "line8", "line9"}, "\n"),
+			},
+			title:      "**TLive 停止通知**",
+			label:      "停止前輸出：",
+			summary:    "本次執行已停止，以下是結束前保留下來的內容。",
+			actionHint: "如需恢復處理，可重新進入該會話或重新執行命令。",
+			wants: []string{
+				"line8",
+				"line9",
+			},
+			notWants: []string{"line1"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := renderWeChatContent(tc.msg)
+			if tc.title != "" && !strings.Contains(content, tc.title) {
+				t.Fatalf("expected content to contain title %q, got %q", tc.title, content)
+			}
+			if tc.label != "" && !strings.Contains(content, tc.label) {
+				t.Fatalf("expected content to contain label %q, got %q", tc.label, content)
+			}
+			if tc.summary != "" && !strings.Contains(content, tc.summary) {
+				t.Fatalf("expected content to contain summary %q, got %q", tc.summary, content)
+			}
+			if tc.actionHint != "" && !strings.Contains(content, tc.actionHint) {
+				t.Fatalf("expected content to contain action hint %q, got %q", tc.actionHint, content)
+			}
+			assertContainsAll(t, content, tc.wants)
+			assertContainsNone(t, content, tc.notWants)
+		})
+	}
+}
+
+func TestRenderWeChatContentTruncatesAndEscapesCodeFence(t *testing.T) {
+	long := strings.Repeat("a", 1300) + "```tail"
+	content := renderWeChatContent(&NotifyMessage{Command: "progress", LastOutput: long})
+
+	if !strings.Contains(content, "**TLive 進度通知**") {
+		t.Fatalf("expected progress title, got %q", content)
+	}
+	if strings.Contains(content, "```tail") {
+		t.Fatalf("expected embedded code fence to be escaped, got %q", content)
+	}
+	if !strings.Contains(content, "'''tail") {
+		t.Fatalf("expected escaped fence marker, got %q", content)
+	}
+	if !strings.Contains(content, "…") {
+		t.Fatalf("expected truncation marker, got %q", content)
+	}
+}
+
+func TestRenderWeChatContentHandlesNilMessage(t *testing.T) {
+	if got := renderWeChatContent(nil); got != "**TLive 通知**" {
+		t.Fatalf("expected default title, got %q", got)
+	}
+}
+
+func TestRenderWeChatContentPreservesValidUTF8AfterTruncation(t *testing.T) {
+	long := strings.Repeat("測", 1300) + "```尾巴"
+	content := renderWeChatContent(&NotifyMessage{Command: "progress", LastOutput: long})
+
+	if !utf8.ValidString(content) {
+		t.Fatalf("expected valid UTF-8 content, got %q", content)
+	}
+	if !strings.Contains(content, "…") {
+		t.Fatalf("expected truncation marker, got %q", content)
+	}
+	if strings.Contains(content, "```尾巴") {
+		t.Fatalf("expected embedded code fence to be escaped, got %q", content)
+	}
+	if !strings.Contains(content, "'''尾巴") {
+		t.Fatalf("expected escaped fence marker, got %q", content)
+	}
+}
+
+func assertContainsAll(t *testing.T, content string, wants []string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(content, want) {
+			t.Fatalf("expected content to contain %q, got %q", want, content)
+		}
+	}
+}
+
+func assertContainsNone(t *testing.T, content string, notWants []string) {
+	t.Helper()
+	for _, notWant := range notWants {
+		if strings.Contains(content, notWant) {
+			t.Fatalf("expected content not to contain %q, got %q", notWant, content)
+		}
+	}
+}
+
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }

--- a/docs/getting-started-cn.md
+++ b/docs/getting-started-cn.md
@@ -170,6 +170,50 @@ tlive doctor
 tlive logs 50
 ```
 
+### IM Bridge 工作目录异常（cwd 变成 `/`）
+
+如果 IM Bridge 回答它当前位于 `/`，或无法安全读取项目文件，请按下面顺序检查日志：
+
+1. 启动时的 `defaultWorkdir`
+   - 确认 bridge 启动日志包含：
+     - 解析后的 `defaultWorkdir`
+     - 当前 `process.cwd()`
+     - 来源：`TL_DEFAULT_WORKDIR` 或回退到 `process.cwd()`
+   - 如果 `defaultWorkdir` 是 `/`、不是绝对路径、不存在，或不是目录，先修正启动配置。
+
+2. Router 的 session 建立过程
+   - 对 fresh chat 或执行 `/new` 之后，确认 router 日志包含：
+     - binding 是新建还是复用
+     - session row 是否被 seed
+     - session 的 `workingDirectory`
+   - 这能确认新 IM 会话是否真的绑定到了预期 cwd 的 bridge session。
+
+3. SDKEngine 的最终 cwd 选择
+   - 在执行前，确认 engine 日志包含：
+     - session 中原本存的 cwd
+     - `defaultWorkdir`
+     - 最终生效的 cwd
+     - cwd 来源
+     - 是否发生 heal
+   - 这是每一轮消息执行前最权威的 cwd 判定点。
+
+**建议手动重现步骤：**
+
+1. 重启 bridge
+2. 在 Telegram 中执行 `/new`
+3. 发送：`請讀取 README.md 第一行，不要修改任何檔案。`
+4. 确认回覆内容与仓库中的文件一致
+5. 如有需要，查看日志：
+
+```bash
+tlive logs 100
+```
+
+如果系统仍然报告 `/`，这些日志应能帮助你判断问题来自：
+- 启动配置
+- session 持久化
+- 执行阶段的 fallback / healing
+
 **常见问题：**
 
 - **"Go Core not found"** — 二进制文件下载不完整，重新运行 `npm install -g tlive` 即可。

--- a/docs/getting-started-cn.md
+++ b/docs/getting-started-cn.md
@@ -74,6 +74,7 @@ TL_ENABLED_CHANNELS=telegram
 # Telegram 示例
 TL_TG_BOT_TOKEN=7823456789:AAF-xxxxx
 TL_TG_CHAT_ID=123456789
+TL_TG_POLL_TIMEOUT=10             # 可选：长轮询频繁 ECONNRESET/socket hang up 时可调低
 
 # Web 终端端口和访问令牌
 TL_PORT=4590

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,6 +74,7 @@ TL_ENABLED_CHANNELS=telegram
 # Telegram example
 TL_TG_BOT_TOKEN=7823456789:AAF-xxxxx
 TL_TG_CHAT_ID=123456789
+TL_TG_POLL_TIMEOUT=10             # optional: lower if long-poll gets ECONNRESET/socket hang up
 
 # Web terminal port and access token
 TL_PORT=4590

--- a/references/troubleshooting.md
+++ b/references/troubleshooting.md
@@ -29,6 +29,19 @@
 5. For Feishu: confirm app is approved and event subscriptions are configured
 6. Check logs for incoming messages: `/tlive logs 200`
 
+## Telegram long-polling unstable (ECONNRESET / socket hang up)
+
+**Symptoms**: Bridge logs repeatedly show `getUpdates` errors such as `ECONNRESET` or `socket hang up`.
+
+**Steps**:
+1. Ensure only one bot instance is running
+   - Stop duplicate bridge sessions and restart once: `tlive stop && tlive start`
+2. Lower Telegram poll timeout
+   - In `~/.tlive/config.env`, set `TL_TG_POLL_TIMEOUT=10`
+   - Restart bridge: `tlive stop && tlive start`
+3. If your region/network needs a proxy, set `TL_TG_PROXY` (or global `TL_PROXY`)
+4. Re-check recent logs: `tlive logs 100`
+
 ## Hook approval not working
 
 **Symptoms**: Claude Code runs without sending permission requests to phone.

--- a/references/troubleshooting.md
+++ b/references/troubleshooting.md
@@ -49,9 +49,30 @@
 2. For Feishu: verify `editMessage` card patching works (check logs for API errors)
 3. Check delivery rate limiting — rapid edits may be throttled
 
-## High memory usage
+## Wrong working directory in IM Bridge
 
-**Symptoms**: Bridge process consumes increasing memory over time.
+**Symptoms**: The IM Bridge says it is in `/`, cannot safely read repository files, or fails to resolve relative project paths after `/new`.
+
+**Steps**:
+1. Check startup `defaultWorkdir` logs
+   - Confirm startup logs show the resolved `defaultWorkdir`, current `process.cwd()`, and whether the source was `TL_DEFAULT_WORKDIR` or fallback `process.cwd()`.
+   - If `defaultWorkdir` is `/`, non-absolute, missing, or not a directory, fix startup configuration first.
+2. Check router session bootstrap logs
+   - For a fresh chat or after `/new`, confirm logs show binding creation or reuse, session seeding, and the stored session `workingDirectory`.
+   - This verifies the IM chat was attached to the expected bridge session.
+3. Check SDKEngine cwd-selection logs
+   - Confirm the engine logs show stored session cwd, `defaultWorkdir`, final effective cwd, source of selection, and whether healing occurred.
+   - This is the authoritative per-message cwd decision.
+4. Reproduce with a safe read-only prompt
+   - Restart the bridge.
+   - In Telegram, run `/new`.
+   - Send: `請讀取 README.md 第一行，不要修改任何檔案。`
+   - Confirm the reply matches the repository file content.
+5. Inspect logs if the issue persists
+   - Run: `tlive logs 100`
+   - Determine whether `/` came from startup configuration, session persistence, or execution-time fallback/healing.
+
+## High memory usage
 
 **Steps**:
 1. Check status: `/tlive status`

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -108,7 +108,7 @@ function daemonStart() {
     ...process.env,
     ...config,
     TL_RUNTIME: runtime,
-    TL_DEFAULT_WORKDIR: process.env.TL_DEFAULT_WORKDIR || process.cwd(),
+    TL_DEFAULT_WORKDIR: process.env.TL_DEFAULT_WORKDIR || config.TL_DEFAULT_WORKDIR || process.cwd(),
   };
 
   const child = spawn(process.execPath, [BRIDGE_ENTRY], {
@@ -222,7 +222,7 @@ function ensureBridgeRunning() {
     ...process.env,
     ...config,
     TL_RUNTIME: runtime,
-    TL_DEFAULT_WORKDIR: process.env.TL_DEFAULT_WORKDIR || process.cwd(),
+    TL_DEFAULT_WORKDIR: process.env.TL_DEFAULT_WORKDIR || config.TL_DEFAULT_WORKDIR || process.cwd(),
   };
 
   try {

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -163,10 +163,10 @@ async function daemonStatus() {
     if (resp.ok) {
       console.log(`Web terminal: running at http://localhost:${port}`);
     } else {
-      console.log('Web terminal: not running (start with: tlive <cmd>)');
+      console.log('Web terminal: not running (IM-only mode). Start one with: tlive <cmd>');
     }
   } catch {
-    console.log('Web terminal: not running (start with: tlive <cmd>)');
+    console.log('Web terminal: not running (IM-only mode). Start one with: tlive <cmd>');
   }
 }
 
@@ -319,10 +319,10 @@ async function runDoctor() {
       console.log('API:');
       console.log(body);
     } else {
-      console.log(`API: unreachable (port ${port})`);
+      console.log(`API: unreachable (port ${port}) — likely IM-only mode. Start Web terminal with: tlive <cmd>`);
     }
   } catch {
-    console.log(`API: unreachable (port ${port})`);
+    console.log(`API: unreachable (port ${port}) — likely IM-only mode. Start Web terminal with: tlive <cmd>`);
   }
 
   console.log('');

--- a/scripts/hook-handler.mjs
+++ b/scripts/hook-handler.mjs
@@ -3,6 +3,15 @@ import { readFileSync, writeFileSync, appendFileSync, existsSync, unlinkSync, mk
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
+function denyPermission() {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PermissionRequest',
+      decision: { behavior: 'deny' },
+    },
+  }));
+}
+
 // Read stdin
 let input = '';
 for await (const chunk of process.stdin) {
@@ -102,19 +111,24 @@ try {
     signal: AbortSignal.timeout(300_000),
   });
 } catch {
+  denyPermission();
   process.exit(0);
 }
 
-if (!response.ok) process.exit(0);
+if (!response.ok) {
+  denyPermission();
+  process.exit(0);
+}
 
 let body;
 try {
   body = await response.json();
 } catch {
+  denyPermission();
   process.exit(0);
 }
 
-const decision = body.decision || 'allow';
+const decision = body.decision || 'deny';
 const updatedInput = body.updated_input;
 
 // For AskUserQuestion: save the IM answer so PostToolUse can inject it as context.
@@ -159,11 +173,9 @@ switch (decision) {
     break;
   }
   case 'deny':
-    process.stdout.write(JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PermissionRequest',
-        decision: { behavior: 'deny' },
-      },
-    }));
+    denyPermission();
+    break;
+  default:
+    denyPermission();
     break;
 }


### PR DESCRIPTION
## Summary
- heal bridge working-directory selection, fail closed on permission request errors, and improve IM troubleshooting guidance
- add core WeChat notifier relay support with safer webhook response handling and expanded relay tests
- improve IM-only diagnostics in CLI (`tlive status` / `tlive doctor`) so missing Core API in bridge-only mode is clearly explained
- add configurable Telegram long-poll timeout (`TL_TG_POLL_TIMEOUT`) and document tuning for `ECONNRESET` / `socket hang up`

## Test plan
- [x] `npm --prefix "/Users/w/Documents/Playground/tlive/bridge" run build`
- [x] `npm run build`
- [x] Manual verify: `tlive status` and `tlive doctor` show IM-only hints
- [x] Manual verify: `tlive sleep 20` + `curl /api/status` responds while session is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)