### PR TITLE
Fix permission hook fail-closed behavior and Telegram polling resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ Claude Code runs normally in your terminal (no wrapper needed)
 ```
 
 **Safe by design:**
-- Timeout defaults to **deny** (not allow)
+- If Go Core is unreachable, hooks pass through locally (zero impact on normal usage)
+- Once Go Core accepts a PermissionRequest, timeout/error defaults to **deny** (not allow)
 - Shows exact tool name and command before you approve
-- Hook script checks if Go Core is running — if not, passes through (zero impact on normal usage)
 - Works with any Claude Code session, no wrapper needed
 
 **Pause when you're at your desk:**

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ TL_ENABLED_CHANNELS=telegram,discord
 TL_TG_BOT_TOKEN=...
 TL_TG_CHAT_ID=...
 TL_TG_REQUIRE_MENTION=true        # @bot required in groups
+TL_TG_POLL_TIMEOUT=10             # optional: lower if long-poll gets ECONNRESET/socket hang up
 TL_TG_DISABLE_LINK_PREVIEW=true   # cleaner messages
 
 # Discord

--- a/bridge/src/channels/telegram.ts
+++ b/bridge/src/channels/telegram.ts
@@ -2,6 +2,7 @@ import { Bot, InputFile, type Api, type RawApi } from 'grammy';
 import { run, type RunnerHandle } from '@grammyjs/runner';
 import { apiThrottler } from '@grammyjs/transformer-throttler';
 import { createServer, type Server } from 'node:http';
+import { Agent as HttpsAgent } from 'node:https';
 import { BaseChannelAdapter, registerAdapterFactory } from './base.js';
 import type { InboundMessage, OutboundMessage, SendResult, FileAttachment } from './types.js';
 import { loadConfig } from '../config.js';
@@ -17,6 +18,7 @@ interface TelegramConfig {
   webhookUrl: string;
   webhookSecret: string;
   webhookPort: number;
+  pollTimeout: number;
   disableLinkPreview: boolean;
   proxy: string;
 }
@@ -53,10 +55,21 @@ export class TelegramAdapter extends BaseChannelAdapter {
   }
 
   async start(): Promise<void> {
-    const agent = createNodeAgent(this.config.proxy);
-    this.bot = new Bot(this.config.botToken, agent
-      ? { client: { baseFetchConfig: { agent, compress: true } } }
-      : {});
+    const proxyAgent = createNodeAgent(this.config.proxy);
+    const keepAliveAgent = new HttpsAgent({
+      keepAlive: true,
+      maxSockets: 32,
+      keepAliveMsecs: 30_000,
+    });
+    const agent = proxyAgent ?? keepAliveAgent;
+    this.bot = new Bot(this.config.botToken, {
+      client: {
+        baseFetchConfig: {
+          agent,
+          compress: true,
+        },
+      },
+    });
 
     if (this.config.proxy) {
       console.log(`[telegram] Using proxy: ${maskProxyUrl(this.config.proxy)}`);
@@ -232,7 +245,10 @@ export class TelegramAdapter extends BaseChannelAdapter {
       await this.bot.api.deleteWebhook();
       this.runnerHandle = run(this.bot, {
         runner: {
+          maxRetryTime: 24 * 60 * 60 * 1000,
+          retryInterval: 'quadratic',
           fetch: {
+            timeout: Math.max(1, this.config.pollTimeout || 30),
             allowed_updates: ['message', 'callback_query', 'message_reaction'],
           },
         },

--- a/bridge/src/config.ts
+++ b/bridge/src/config.ts
@@ -34,6 +34,8 @@ export interface Config {
     webhookSecret: string;
     /** Webhook listen port (default: 8443) */
     webhookPort: number;
+    /** Long-poll timeout in seconds for getUpdates (default: 30) */
+    pollTimeout: number;
     /** Disable link previews in outbound messages (default: true) */
     disableLinkPreview: boolean;
     /** HTTP/SOCKS proxy URL — overrides global TL_PROXY */
@@ -128,6 +130,7 @@ export function loadConfig(): Config {
       webhookUrl: get('TL_TG_WEBHOOK_URL'),
       webhookSecret: get('TL_TG_WEBHOOK_SECRET'),
       webhookPort: parseInt(get('TL_TG_WEBHOOK_PORT', '8443'), 10),
+      pollTimeout: parseInt(get('TL_TG_POLL_TIMEOUT', '30'), 10),
       disableLinkPreview: get('TL_TG_DISABLE_LINK_PREVIEW', 'true') !== 'false',
       proxy: get('TL_TG_PROXY') || globalProxy,
     },

--- a/config.env.example
+++ b/config.env.example
@@ -21,6 +21,9 @@ TL_TG_CHAT_ID=
 TL_TG_ALLOWED_USERS=
 # Require @mention in groups (default: true)
 TL_TG_REQUIRE_MENTION=true
+# Long-poll timeout seconds for getUpdates (default: 30)
+# Lower this (e.g. 10) if your network frequently resets long-lived Telegram connections
+# TL_TG_POLL_TIMEOUT=10
 # Disable link previews in messages (default: true)
 TL_TG_DISABLE_LINK_PREVIEW=true
 # Webhook mode (optional — omit to use long-polling)

--- a/docs/getting-started-cn.md
+++ b/docs/getting-started-cn.md
@@ -74,6 +74,7 @@ TL_ENABLED_CHANNELS=telegram
 # Telegram 示例
 TL_TG_BOT_TOKEN=7823456789:AAF-xxxxx
 TL_TG_CHAT_ID=123456789
+TL_TG_POLL_TIMEOUT=10             # 可选：长轮询频繁 ECONNRESET/socket hang up 时可调低
 
 # Web 终端端口和访问令牌
 TL_PORT=4590

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,6 +74,7 @@ TL_ENABLED_CHANNELS=telegram
 # Telegram example
 TL_TG_BOT_TOKEN=7823456789:AAF-xxxxx
 TL_TG_CHAT_ID=123456789
+TL_TG_POLL_TIMEOUT=10             # optional: lower if long-poll gets ECONNRESET/socket hang up
 
 # Web terminal port and access token
 TL_PORT=4590

--- a/references/troubleshooting.md
+++ b/references/troubleshooting.md
@@ -29,6 +29,19 @@
 5. For Feishu: confirm app is approved and event subscriptions are configured
 6. Check logs for incoming messages: `/tlive logs 200`
 
+## Telegram long-polling unstable (ECONNRESET / socket hang up)
+
+**Symptoms**: Bridge logs repeatedly show `getUpdates` errors such as `ECONNRESET` or `socket hang up`.
+
+**Steps**:
+1. Ensure only one bot instance is running
+   - Stop duplicate bridge sessions and restart once: `tlive stop && tlive start`
+2. Lower Telegram poll timeout
+   - In `~/.tlive/config.env`, set `TL_TG_POLL_TIMEOUT=10`
+   - Restart bridge: `tlive stop && tlive start`
+3. If your region/network needs a proxy, set `TL_TG_PROXY` (or global `TL_PROXY`)
+4. Re-check recent logs: `tlive logs 100`
+
 ## Hook approval not working
 
 **Symptoms**: Claude Code runs without sending permission requests to phone.

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -163,10 +163,10 @@ async function daemonStatus() {
     if (resp.ok) {
       console.log(`Web terminal: running at http://localhost:${port}`);
     } else {
-      console.log('Web terminal: not running (start with: tlive <cmd>)');
+      console.log('Web terminal: not running (IM-only mode). Start one with: tlive <cmd>');
     }
   } catch {
-    console.log('Web terminal: not running (start with: tlive <cmd>)');
+    console.log('Web terminal: not running (IM-only mode). Start one with: tlive <cmd>');
   }
 }
 
@@ -319,10 +319,10 @@ async function runDoctor() {
       console.log('API:');
       console.log(body);
     } else {
-      console.log(`API: unreachable (port ${port})`);
+      console.log(`API: unreachable (port ${port}) — likely IM-only mode. Start Web terminal with: tlive <cmd>`);
     }
   } catch {
-    console.log(`API: unreachable (port ${port})`);
+    console.log(`API: unreachable (port ${port}) — likely IM-only mode. Start Web terminal with: tlive <cmd>`);
   }
 
   console.log('');

--- a/scripts/hook-handler.mjs
+++ b/scripts/hook-handler.mjs
@@ -3,6 +3,15 @@ import { readFileSync, writeFileSync, appendFileSync, existsSync, unlinkSync, mk
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
+function denyPermission() {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PermissionRequest',
+      decision: { behavior: 'deny' },
+    },
+  }));
+}
+
 // Read stdin
 let input = '';
 for await (const chunk of process.stdin) {
@@ -102,19 +111,24 @@ try {
     signal: AbortSignal.timeout(300_000),
   });
 } catch {
+  denyPermission();
   process.exit(0);
 }
 
-if (!response.ok) process.exit(0);
+if (!response.ok) {
+  denyPermission();
+  process.exit(0);
+}
 
 let body;
 try {
   body = await response.json();
 } catch {
+  denyPermission();
   process.exit(0);
 }
 
-const decision = body.decision || 'allow';
+const decision = body.decision || 'deny';
 const updatedInput = body.updated_input;
 
 // For AskUserQuestion: save the IM answer so PostToolUse can inject it as context.
@@ -159,11 +173,9 @@ switch (decision) {
     break;
   }
   case 'deny':
-    process.stdout.write(JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'PermissionRequest',
-        decision: { behavior: 'deny' },
-      },
-    }));
+    denyPermission();
+    break;
+  default:
+    denyPermission();
     break;
 }


### PR DESCRIPTION
## Summary
- keep the permission hook fail-closed after control has already been handed to Go Core
- reduce Telegram `ECONNRESET` / `socket hang up` incidents with configurable polling timeout plus keepalive/backoff tuning
- document the new Telegram tuning knob and clarify IM-only diagnostics in `tlive status` / `tlive doctor`

## Test plan
- [x] `npm --prefix bridge test`
- [x] `npm run test:go`
- [x] `npm --prefix bridge run build`
- [x] Manual verify: `tlive status` / `tlive doctor` explain IM-only mode
- [x] Manual verify: lowering Telegram poll timeout stabilizes long-polling on this machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)